### PR TITLE
Run workflow on all open PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches:
       - main
+  pull_request_target:
+    types: [opened]
 
 jobs:
   build:


### PR DESCRIPTION
This runs the build job on all open PRs which will include that from external repos. Addresses issue #33 

You may have to update your settings to allow workflows to run - see https://github.com/Matthew-Wise/Umbraco-CSP-manager/settings/actions and likely the section `Fork pull request workflows from outside collaborators`