### PR TITLE
Add in directives to the title in the editor box - i46

### DIFF
--- a/src/Umbraco.Community.CSPManager/wwwroot/backoffice/manage-csp/edit.html
+++ b/src/Umbraco.Community.CSPManager/wwwroot/backoffice/manage-csp/edit.html
@@ -38,6 +38,10 @@
 		border-top-left-radius: 0;
 		border-top-right-radius: 0;
 	}
+    .csp-subtitle {
+        font-size: 14px;
+        font-weight: normal;
+    }
 </style>
 
 <div ng-controller="cspManagerEditController as vm">

--- a/src/Umbraco.Community.CSPManager/wwwroot/backoffice/manage-csp/manage/manage-csp.html
+++ b/src/Umbraco.Community.CSPManager/wwwroot/backoffice/manage-csp/manage/manage-csp.html
@@ -41,7 +41,7 @@
 					<div class="control-group umb-control-group">
 						<div class="umb-el-wrap">
 							<div class="control-header">
-								<label class="control-label">Directives Set</label>
+								<label class="control-label">Directive Set</label>
 							</div>
 							<div class="controls" style="
 								display: grid;

--- a/src/Umbraco.Community.CSPManager/wwwroot/backoffice/manage-csp/manage/manage-csp.html
+++ b/src/Umbraco.Community.CSPManager/wwwroot/backoffice/manage-csp/manage/manage-csp.html
@@ -9,7 +9,9 @@
 
 			<div ng-repeat="(sourceIndex, source) in vm.definition.Sources" class="mb2">
 				<button type="button" class="csp-accordion-btn" ng-class="{'active': vm.expanded.includes(sourceIndex) ? true : false}" ng-click="vm.expandAccordion($event, sourceIndex)">
-					Source: {{source.Source}}
+					<span>Source: {{source.Source}}<br/>
+						<span class="csp-subtitle"><b>Directives:</b> <span ng-repeat="(dIndex, directive) in source.Directives">{{directive}}{{$last ? '' : ', '}}</span></span>
+					</span>
 					<span class="ml-auto">
 						<uui-icon-registry-essential>
 							<uui-action-bar>


### PR DESCRIPTION
This includes the directive list into the title bar as suggested in https://github.com/Matthew-Wise/Umbraco-CSP-manager/issues/46 It uses the VM data so auto updates as you tick/untick.

Here's an example of the two pages that use the list.

Back office list:
![image](https://github.com/user-attachments/assets/802e25bb-86ba-44d9-9068-0f7667cef900)

Front end list:
![image](https://github.com/user-attachments/assets/6f91ada7-5c4a-41f6-84b5-90d2722a68ab)

I also corrected a typo of "Directives Set" -> "Directive Set" in the editor.
