### PR TITLE
👷 Fix to compile CSPManager Client on build

### DIFF
--- a/src/Umbraco.Community.CSPManager/Umbraco.Community.CSPManager.csproj
+++ b/src/Umbraco.Community.CSPManager/Umbraco.Community.CSPManager.csproj
@@ -52,4 +52,40 @@
 			<PackagePath>\</PackagePath>
 		</None>
 	</ItemGroup>
+
+	<!--
+      1. Install npm packages
+      "Inputs" and "Outputs" are used for incremental builds. If all output items are up-to-date, MSBuild
+	skips the target.
+      The first time the task is executed. Then, it only runs when you change the package.json file.
+      Documentation:
+	https://learn.microsoft.com/en-us/visualstudio/msbuild/incremental-builds?WT.mc_id=DT-MVP-5003978
+   -->
+	<Target Name="NpmInstall" Inputs="Client/package.json"
+		Outputs="Client/node_modules/.install-stamp">
+		<!--
+        Use npm install or npm ci depending on RestorePackagesWithLockFile value.
+        Uncomment the following lines if you want to use this feature:
+
+        <PropertyGroup>
+          <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+        </PropertyGroup>
+     -->
+		<!--<Exec
+		Command="npm ci" WorkingDirectory="Client" Condition="'$(RestorePackagesWithLockFile)' ==
+		'true'" />-->
+		<Exec Command="npm install" WorkingDirectory="Client"
+			Condition="'$(RestorePackagesWithLockFile)' != 'true'" />
+
+		<!-- Write the stamp file, so incremental builds work -->
+		<Touch Files="Client/node_modules/.install-stamp" AlwaysCreate="true" />
+	</Target>
+
+	<!--
+      2. Run npm run build before building the .NET project.
+      MSBuild runs NpmInstall before this task because of the DependsOnTargets attribute.
+   -->
+	<Target Name="NpmRunBuild" DependsOnTargets="NpmInstall" BeforeTargets="BeforeBuild">
+		<Exec Command="npm run build" WorkingDirectory="Client" />
+	</Target>
 </Project>


### PR DESCRIPTION
Fixes #59

The Client project wasn't being compiled into the DLL on build