### PR TITLE
Migrate NuGet publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,11 +1,15 @@
 # Umbraco.Community.CSPManager
 
-[![Platform](https://img.shields.io/badge/Umbraco-17+-%233544B1?style=flat&logo=umbraco)](https://umbraco.com/products/umbraco-cms/)
-[![Downloads](https://img.shields.io/nuget/dt/Umbraco.Community.CSPManager?color=cc9900)](https://www.nuget.org/packages/Umbraco.Community.CSPManager/)
-[![NuGet](https://img.shields.io/nuget/vpre/Umbraco.Community.CSPManager?color=0273B3)](https://www.nuget.org/packages/Umbraco.Community.CSPManager)
-[![GitHub license](https://img.shields.io/github/license/Matthew-Wise/Umbraco-CSP-manager?color=8AB803)](https://github.com/Matthew-Wise/Umbraco-CSP-manager/blob/main/LICENSE)
-[![Build](https://github.com/Matthew-Wise/Umbraco-CSP-manager/actions/workflows/csp-manager.yml/badge.svg?event=push)](https://github.com/Matthew-Wise/Umbraco-CSP-manager/blob/main/.github/workflows/csp-manager.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11084/badge)](https://www.bestpractices.dev/projects/11084)
+[![Build](https://github.com/Matthew-Wise/Umbraco-CSP-manager/actions/workflows/csp-manager.yml/badge.svg?event=push)](https://github.com/Matthew-Wise/Umbraco-CSP-manager/blob/main/.github/workflows/csp-manager.yml)
+[![Platform](https://img.shields.io/badge/Umbraco-17+-%233544B1?style=flat&logo=umbraco)](https://umbraco.com/products/umbraco-cms/)
+[![GitHub license](https://img.shields.io/github/license/Matthew-Wise/Umbraco-CSP-manager?color=8AB803)](https://github.com/Matthew-Wise/Umbraco-CSP-manager/blob/main/LICENSE)
+[![NuGet](https://img.shields.io/nuget/vpre/Umbraco.Community.CSPManager?color=0273B3)](https://www.nuget.org/packages/Umbraco.Community.CSPManager)
+[![Downloads](https://img.shields.io/nuget/dt/Umbraco.Community.CSPManager?color=cc9900)](https://www.nuget.org/packages/Umbraco.Community.CSPManager/)
+
+
+
+
 
 A comprehensive Content Security Policy (CSP) management package for Umbraco CMS that helps protect your website from XSS attacks and other code injection vulnerabilities. Manage CSP headers for both frontend and backend through an intuitive backoffice interface.
 

--- a/.github/workflows/csp-manager.yml
+++ b/.github/workflows/csp-manager.yml
@@ -107,5 +107,11 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: MattWise
+
       - name: Publish to NuGet
-        run: dotnet nuget push ./build-out/*.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ./build-out/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/usync.yml
+++ b/.github/workflows/usync.yml
@@ -95,11 +95,17 @@ jobs:
         with:
           subject-path: '${{ env.OUT_FOLDER }}*.nupkg'
 
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: MattWise
+
       - name: Publish to NuGet
         run: |
           for package in ${{ env.OUT_FOLDER }}*.nupkg; do
             echo "Publishing $package"
-            dotnet nuget push "$package" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+            dotnet nuget push "$package" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
           done
 
   release-usync-complete:
@@ -136,9 +142,15 @@ jobs:
         with:
           subject-path: '${{ env.OUT_FOLDER }}*.nupkg'
 
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: MattWise
+
       - name: Publish to NuGet
         run: |
           for package in ${{ env.OUT_FOLDER }}*.nupkg; do
             echo "Publishing $package"
-            dotnet nuget push "$package" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+            dotnet nuget push "$package" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
           done

--- a/.gitignore
+++ b/.gitignore
@@ -370,3 +370,7 @@ src/**/App_Plugins/UmbracoCommunityCSPManager/
 **/App_Plugins/uSyncCspComplete/
 .claude/worktrees
 /.playwright-mcp
+
+# Local NuGet test packages and scratch test sites
+/local-packages/
+/test-sites/

--- a/docs/README_nuget.md
+++ b/docs/README_nuget.md
@@ -1,11 +1,11 @@
 # Umbraco.Community.CSPManager
 
-[![Platform](https://img.shields.io/badge/Umbraco-17+-%233544B1?style=flat&logo=umbraco)](https://umbraco.com/products/umbraco-cms/)
-[![Downloads](https://img.shields.io/nuget/dt/Umbraco.Community.CSPManager?color=cc9900)](https://www.nuget.org/packages/Umbraco.Community.CSPManager/)
-[![NuGet](https://img.shields.io/nuget/vpre/Umbraco.Community.CSPManager?color=0273B3)](https://www.nuget.org/packages/Umbraco.Community.CSPManager)
-[![GitHub license](https://img.shields.io/github/license/Matthew-Wise/Umbraco-CSP-manager?color=8AB803)](https://github.com/Matthew-Wise/Umbraco-CSP-manager/blob/main/LICENSE)
-[![Build](https://github.com/Matthew-Wise/Umbraco-CSP-manager/actions/workflows/csp-manager.yml/badge.svg?event=push)](https://github.com/Matthew-Wise/Umbraco-CSP-manager/blob/main/.github/workflows/csp-manager.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11084/badge)](https://www.bestpractices.dev/projects/11084)
+[![Build](https://github.com/Matthew-Wise/Umbraco-CSP-manager/actions/workflows/csp-manager.yml/badge.svg?event=push)](https://github.com/Matthew-Wise/Umbraco-CSP-manager/blob/main/.github/workflows/csp-manager.yml)
+[![Platform](https://img.shields.io/badge/Umbraco-17+-%233544B1?style=flat&logo=umbraco)](https://umbraco.com/products/umbraco-cms/)
+[![GitHub license](https://img.shields.io/github/license/Matthew-Wise/Umbraco-CSP-manager?color=8AB803)](https://github.com/Matthew-Wise/Umbraco-CSP-manager/blob/main/LICENSE)
+[![NuGet](https://img.shields.io/nuget/vpre/Umbraco.Community.CSPManager?color=0273B3)](https://www.nuget.org/packages/Umbraco.Community.CSPManager)
+[![Downloads](https://img.shields.io/nuget/dt/Umbraco.Community.CSPManager?color=cc9900)](https://www.nuget.org/packages/Umbraco.Community.CSPManager/)
 
 A Content Security Policy management package for Umbraco CMS. Manage CSP headers for both frontend and backoffice through an intuitive backoffice interface.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,12 +5,12 @@ nav_order: 1
 
 # CSP Manager for Umbraco
 
-[![Platform](https://img.shields.io/badge/Umbraco-17+-%233544B1?style=flat&logo=umbraco){: height="20" }](https://umbraco.com/products/umbraco-cms/)
-[![Downloads](https://img.shields.io/nuget/dt/Umbraco.Community.CSPManager?color=cc9900){: height="20" }](https://www.nuget.org/packages/Umbraco.Community.CSPManager/)
-[![NuGet](https://img.shields.io/nuget/vpre/Umbraco.Community.CSPManager?color=0273B3){: height="20" }](https://www.nuget.org/packages/Umbraco.Community.CSPManager)
-[![GitHub license](https://img.shields.io/github/license/Matthew-Wise/Umbraco-CSP-manager?color=8AB803){: height="20" }](https://github.com/Matthew-Wise/Umbraco-CSP-manager/blob/main/LICENSE)
-[![Build](https://github.com/Matthew-Wise/Umbraco-CSP-manager/actions/workflows/csp-manager.yml/badge.svg?event=push){: height="20" }](https://github.com/Matthew-Wise/Umbraco-CSP-manager/blob/main/.github/workflows/csp-manager.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11084/badge){: height="20" }](https://www.bestpractices.dev/projects/11084)
+[![Build](https://github.com/Matthew-Wise/Umbraco-CSP-manager/actions/workflows/csp-manager.yml/badge.svg?event=push){: height="20" }](https://github.com/Matthew-Wise/Umbraco-CSP-manager/blob/main/.github/workflows/csp-manager.yml)
+[![Platform](https://img.shields.io/badge/Umbraco-17+-%233544B1?style=flat&logo=umbraco){: height="20" }](https://umbraco.com/products/umbraco-cms/)
+[![GitHub license](https://img.shields.io/github/license/Matthew-Wise/Umbraco-CSP-manager?color=8AB803){: height="20" }](https://github.com/Matthew-Wise/Umbraco-CSP-manager/blob/main/LICENSE)
+[![NuGet](https://img.shields.io/nuget/vpre/Umbraco.Community.CSPManager?color=0273B3){: height="20" }](https://www.nuget.org/packages/Umbraco.Community.CSPManager)
+[![Downloads](https://img.shields.io/nuget/dt/Umbraco.Community.CSPManager?color=cc9900){: height="20" }](https://www.nuget.org/packages/Umbraco.Community.CSPManager/)
 
 A Content Security Policy management package for Umbraco CMS. Manage CSP headers for your frontend and backoffice through the Umbraco backoffice.
 

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="local" value="./local-packages" />
+  </packageSources>
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,5 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="local" value="./local-packages" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
## Summary
- Replaces long-lived `NUGET_API_KEY` secrets with short-lived OIDC tokens via `NuGet/login@v1` in all three release jobs (`nuget-csp`, `nuget-usync`, `nuget-usync-complete`)
- Reorders badges in README and docs (OpenSSF + Build first)

## Prerequisites
- Three GitHub environments must exist: `nuget-csp`, `nuget-usync`, `nuget-usync-complete`
- Three Trusted Publishing policies configured on nuget.org (one per package, referencing the correct workflow file and environment)

## Test plan
- [ ] Verify CI build job passes on this PR
- [ ] On merge, trigger a release and confirm OIDC login succeeds and package publishes without `NUGET_API_KEY`
- [ ] Remove `NUGET_API_KEY` from Deploy Keys once all three packages have published successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)