### PR TITLE
ci: skip build job for uSync release tags

### DIFF
--- a/.github/workflows/csp-manager.yml
+++ b/.github/workflows/csp-manager.yml
@@ -26,6 +26,7 @@ on:
 
 jobs:
   build:
+    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'usync-')
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- Adds an `if` condition to the `build` job in `csp-manager.yml` to skip execution when a release event is triggered by a tag starting with `usync-`
- Prevents the CSP Manager build workflow from running unnecessarily during uSync package releases

## Test plan
- [ ] Verify the `build` job runs normally on push and PR events
- [ ] Verify the `build` job runs on a CSP Manager release tag (e.g. `17.0.0`)
- [ ] Verify the `build` job is skipped on a uSync release tag (e.g. `usync-17.0.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)