### PR TITLE
Fix uSync release CI issues

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   report:
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
     steps:
     - uses: dorny/test-reporter@v2
       with:

--- a/.github/workflows/usync.yml
+++ b/.github/workflows/usync.yml
@@ -50,10 +50,10 @@ jobs:
           cache-dependency-path: './src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client/package-lock.json'
 
       - name: Build & Pack uSync
-        run: dotnet pack ${{ env.USYNC_PROJECT }} -c Release -p:Version=0.0.0-ci.${{ github.run_number }} --output ${{ env.OUT_FOLDER }}
+        run: dotnet pack ${{ env.USYNC_PROJECT }} -c Release -p:Version=0.0.0 --output ${{ env.OUT_FOLDER }}
 
       - name: Build & Pack uSync Complete
-        run: dotnet pack ${{ env.COMPLETE_PROJECT }} -c Release -p:Version=0.0.0-ci.${{ github.run_number }} -p:USyncMinVersion=0.0.0-ci.${{ github.run_number }} --output ${{ env.OUT_FOLDER }}
+        run: dotnet pack ${{ env.COMPLETE_PROJECT }} -c Release -p:Version=0.0.0 --output ${{ env.OUT_FOLDER }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Umbraco.Community.CSPManager.uSync.Complete.csproj
+++ b/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Umbraco.Community.CSPManager.uSync.Complete.csproj
@@ -19,7 +19,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <USyncMinVersion Condition="'$(USyncMinVersion)' == ''">17.0.0-0</USyncMinVersion>
     <UseProjectReferences Condition="'$(UseProjectReferences)' == ''">true</UseProjectReferences>
   </PropertyGroup>
 
@@ -31,7 +30,7 @@
     <ProjectReference Include="..\Umbraco.Community.CSPManager.uSync\Umbraco.Community.CSPManager.uSync.csproj"
                       Condition="'$(UseProjectReferences)' == 'true'" />
     <PackageReference Include="Umbraco.Community.CSPManager.uSync"
-                      VersionOverride="[$(USyncMinVersion), 18.0.0)"
+                      VersionOverride="[17.0.0-alpha, 18.0.0)"
                       Condition="'$(UseProjectReferences)' != 'true'" />
   </ItemGroup>
 

--- a/src/uSync/Umbraco.Community.CSPManager.uSync/Umbraco.Community.CSPManager.uSync.csproj
+++ b/src/uSync/Umbraco.Community.CSPManager.uSync/Umbraco.Community.CSPManager.uSync.csproj
@@ -19,7 +19,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <CspManagerMinVersion Condition="'$(CspManagerMinVersion)' == ''">17.0.0-0</CspManagerMinVersion>
     <UseProjectReferences Condition="'$(UseProjectReferences)' == ''">true</UseProjectReferences>
   </PropertyGroup>
 
@@ -28,7 +27,7 @@
     <ProjectReference Include="..\..\Umbraco.Community.CSPManager\Umbraco.Community.CSPManager.csproj"
                       Condition="'$(UseProjectReferences)' == 'true'" />
     <PackageReference Include="Umbraco.Community.CSPManager"
-                      VersionOverride="[$(CspManagerMinVersion), 18.0.0)"
+                      VersionOverride="[17.0.0-alpha, 18.0.0)"
                       Condition="'$(UseProjectReferences)' != 'true'">
       <ExcludeAssets>buildTransitive;build</ExcludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- Skip `test-report` workflow when CSP Manager build is skipped (triggered by uSync release tags)
- Simplify CI build version from `0.0.0-ci.{run_number}` to `0.0.0` to match CSP Manager pattern
- Remove `USyncMinVersion`/`CspManagerMinVersion` MSBuild properties and hardcode dependency ranges as `[17.0.0-alpha, 18.0.0)` — the `-0` suffix was being rejected by NuGet.org as an invalid pre-release identifier
- Remove now-dead `USyncMinVersion` parameter from the build job

## Test plan

- [ ] Verify CI build passes on this PR
- [ ] Verify a uSync release tag triggers only `uSync Build`, not `CSP Manager Build`
- [ ] Verify `test-report` workflow is skipped when CSP Manager build is skipped
- [ ] Verify released packages have valid NuGet dependency ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)