### PR TITLE
fix: resolve 6 open Dependabot security alerts

### DIFF
--- a/src/Umbraco.Community.CSPManager/Client/package-lock.json
+++ b/src/Umbraco.Community.CSPManager/Client/package-lock.json
@@ -1650,9 +1650,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@umbraco-cms/backoffice": {
-			"version": "17.3.0",
-			"resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.3.0.tgz",
-			"integrity": "sha512-lhlCYCxLa75qNDX5MAv+nmrKn1nKk+JSZYsIzD8HN5B3n0rKsM/LQ/duHYrfseiRpbDHvNCapvUTktvKKPVH5g==",
+			"version": "17.3.4",
+			"resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.3.4.tgz",
+			"integrity": "sha512-7gGc7BXe0zhMHrF25AOKqcxwvobPmKtQoEHAObdePKzHLJYMxxgpVRGvfhfFAzG8SYnbWy4Jz3vKsxgd+xHRQA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3053,9 +3053,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-			"integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+			"integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
 			"dev": true,
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"peer": true,
@@ -4282,9 +4282,9 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-			"integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/broofa",

--- a/src/Umbraco.Community.CSPManager/Client/package.json
+++ b/src/Umbraco.Community.CSPManager/Client/package.json
@@ -37,7 +37,8 @@
 		"csp_evaluator": "^1.1.5"
 	},
 	"overrides": {
-		"dompurify": "^3.2.4"
+		"dompurify": ">=3.4.0",
+		"uuid": ">=14.0.0"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [

--- a/src/Umbraco.Community.CSPManager/Client/tests/import.spec.ts
+++ b/src/Umbraco.Community.CSPManager/Client/tests/import.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 import { test } from "@umbraco/playwright-testhelpers";
-import { CspTestHelpers, CspApiHelpers, TestCspStrings, EntityActions } from "./helpers";
+import { CspTestHelpers, CspDefinitionBuilder, TestCspStrings, EntityActions } from "./helpers";
 import { CspConstants } from "../src/constants";
 
 test.beforeEach(async ({ umbracoUi }) => {
@@ -100,25 +100,33 @@ test.describe("Import Modal UI", () => {
 });
 
 test.describe("Import Full Flow", () => {
-	test.afterEach(async ({ umbracoApi }) => {
-		await new CspApiHelpers(umbracoApi).resetDefinition("frontend");
-	});
-
 	test("Importing a CSP policy closes modal and navigates to the workspace", async ({
 		umbracoUi,
+		page,
 	}) => {
 		const csp = new CspTestHelpers(umbracoUi);
-		await csp.openImportModal("frontend");
-		const modal = csp.importModal();
+		try {
+			await csp.openImportModal("frontend");
+			const modal = csp.importModal();
 
-		await modal.locator("uui-textarea").locator("textarea").fill(TestCspStrings.threeSourceImport);
-		await modal.getByRole("button", { name: "Parse" }).click();
-		await modal.getByRole("button", { name: "Import" }).click();
+			await modal.locator("uui-textarea").locator("textarea").fill(TestCspStrings.threeSourceImport);
+			await modal.getByRole("button", { name: "Parse" }).click();
+			await modal.getByRole("button", { name: "Import" }).click();
 
-		await expect(modal).not.toBeVisible();
-		await expect(csp.workspace()).toBeVisible();
-		await expect(umbracoUi.page).toHaveURL(
-			new RegExp(CspConstants.policyTypes.frontend.value),
-		);
+			await expect(modal).not.toBeVisible();
+			await expect(csp.workspace()).toBeVisible();
+			await expect(umbracoUi.page).toHaveURL(
+				new RegExp(CspConstants.policyTypes.frontend.value),
+			);
+		} finally {
+			// Reset via page.request so browser cookies are used for auth.
+			// umbracoApi cannot be used here as it requires a Bearer token from
+			// localStorage which Umbraco v17 does not store there.
+			const definition = CspDefinitionBuilder.for("frontend").build();
+			await page.request.post(
+				`${process.env.URL ?? "https://localhost:44370"}/umbraco/csp/api/v1/Definitions/save`,
+				{ data: definition, ignoreHTTPSErrors: true },
+			);
+		}
 	});
 });

--- a/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client/package-lock.json
+++ b/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client/package-lock.json
@@ -4240,9 +4240,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",

--- a/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client/package.json
+++ b/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client/package.json
@@ -18,7 +18,8 @@
     "vite": "^6.4.2"
   },
   "overrides": {
-    "dompurify": ">=3.3.2"
+    "dompurify": ">=3.4.0",
+    "uuid": ">=14.0.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": ["esbuild"]


### PR DESCRIPTION
## Summary

- **dompurify** bumped 3.3.3 → 3.4.1, override tightened to `>=3.4.0` in both clients — closes alerts #52, #54, #56, #58 (SAFE_FOR_TEMPLATES bypass, FORBID_TAGS bypass, prototype pollution to XSS, ADD_TAGS short-circuit)
- **uuid** bumped 13.0.0 → 14.0.0 via `npm overrides` in both clients — closes alerts #59, #61 (missing buffer bounds check in v3/v5/v6 when `buf` is provided)
- **@umbraco-cms/backoffice** updated 17.3.0 → 17.3.4 (pulled in automatically by `npm install`)
- **Import Full Flow test** fixed: replaced broken `afterEach({ umbracoApi })` with `try/finally` using `page.request.post` directly. Root cause: `umbracoApi` reads `umb:userAuthTokenResponse` from localStorage to build a Bearer token header, but Umbraco v17 uses HTTP-only cookies for auth — that key is never present. `page.request` sends cookies automatically, which is all the CSP API needs.

## Test plan

- [x] `npm audit` reports 0 vulnerabilities in both clients
- [x] Full Playwright suite: 18/18 passed (was 17/18 before the test fix)
- [x] Frontend build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)