### PR TITLE
ci: bump actions to Node.js 24 runtime

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
     steps:
-    - uses: dorny/test-reporter@v2
+    - uses: dorny/test-reporter@v3
       with:
         artifact: test-results            # artifact name
         name: .NET Tests                  # Name of the check run which will be created


### PR DESCRIPTION
## Summary
- Bump `dorny/test-reporter` from v2 to v3 (v3.0.0 [explicitly upgrades](https://github.com/dorny/test-reporter/releases/tag/v3.0.0) the action runtime to Node.js 24).
- Bump `actions/checkout` from v4 to v6 in the docs workflows; v4 still ships on Node.js 20, v5+ targets Node.js 24.
- Resolves the GitHub Actions deprecation warning for Node.js 20 ahead of the 2026-06-02 forced switch to Node.js 24.

All other actions in the repo (`actions/setup-dotnet@v5`, `actions/setup-node@v6`, `actions/upload-artifact@v4`, `github/codeql-action@v4`, `actions/attest-build-provenance@v2`, `NuGet/login@v1`, `actions/upload-pages-artifact@v3`, `actions/deploy-pages@v4`, `ruby/setup-ruby@v1`) are already on majors that target Node.js 24.

## Test plan
- [ ] CSP Manager Build workflow succeeds on this branch.
- [ ] Test Report workflow runs successfully against the build via `workflow_run` once merged.
- [ ] Docs Build workflow succeeds on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)