### PR TITLE
chore(release): prepare 17.0.0 stable

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,8 +14,8 @@
     <PackageVersion Include="uSync.BackOffice" Version="17.0.4" />
     <PackageVersion Include="uSync.Complete" Version="17.1.3" />
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
-    <PackageVersion Include="Umbraco.Community.CSPManager" Version="17.0.0-beta.1" />
-    <PackageVersion Include="Umbraco.Community.CSPManager.uSync" Version="17.0.0-beta.1" />
+    <PackageVersion Include="Umbraco.Community.CSPManager" Version="17.0.0" />
+    <PackageVersion Include="Umbraco.Community.CSPManager.uSync" Version="17.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="SystemTextJson.JsonDiffPatch.NUnit" Version="2.0.0" />

--- a/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Umbraco.Community.CSPManager.uSync.Complete.csproj
+++ b/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Umbraco.Community.CSPManager.uSync.Complete.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="..\Umbraco.Community.CSPManager.uSync\Umbraco.Community.CSPManager.uSync.csproj"
                       Condition="'$(UseProjectReferences)' == 'true'" />
     <PackageReference Include="Umbraco.Community.CSPManager.uSync"
-                      VersionOverride="[17.0.0-alpha, 18.0.0)"
+                      VersionOverride="[17.0.0-0, 18.0.0)"
                       Condition="'$(UseProjectReferences)' != 'true'" />
   </ItemGroup>
 

--- a/src/uSync/Umbraco.Community.CSPManager.uSync/Umbraco.Community.CSPManager.uSync.csproj
+++ b/src/uSync/Umbraco.Community.CSPManager.uSync/Umbraco.Community.CSPManager.uSync.csproj
@@ -27,7 +27,7 @@
     <ProjectReference Include="..\..\Umbraco.Community.CSPManager\Umbraco.Community.CSPManager.csproj"
                       Condition="'$(UseProjectReferences)' == 'true'" />
     <PackageReference Include="Umbraco.Community.CSPManager"
-                      VersionOverride="[17.0.0-alpha, 18.0.0)"
+                      VersionOverride="[17.0.0-0, 18.0.0)"
                       Condition="'$(UseProjectReferences)' != 'true'">
       <ExcludeAssets>buildTransitive;build</ExcludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Pre-release housekeeping for v17.0.0 stable across all three packages (CSP Manager, uSync, uSync Complete). Per CLAUDE.md the published version flows through CI via `-p:Version=$tag_name`, so no `<Version>` is added to any csproj — only the central package versions and dependency ranges are updated.

- Bump central versions in `src/Directory.Packages.props`: `Umbraco.Community.CSPManager` and `Umbraco.Community.CSPManager.uSync` `17.0.0-beta.1` → `17.0.0`.
- Tighten the cross-package `VersionOverride` lower bound from `[17.0.0-alpha, 18.0.0)` → `[17.0.0-0, 18.0.0)` in both uSync csproj files (matches the convention documented in CLAUDE.md and the per-package CLAUDE.md notes).

After this PR merges, releases will be cut in order:
1. GitHub Release `17.0.0` → triggers `csp-manager.yml` → publishes `Umbraco.Community.CSPManager 17.0.0`.
2. Git tag `usync-17.0.0` → triggers `usync.yml::release-usync` → publishes `Umbraco.Community.CSPManager.uSync 17.0.0`.
3. Git tag `usync-complete-17.0.0` → triggers `usync.yml::release-usync-complete` → publishes `Umbraco.Community.CSPManager.uSync.Complete 17.0.0`.

The order matters because each package's restore at pack time resolves the previous one from NuGet.org.

## Test plan

- [x] `dotnet build src/Umbraco.Community.CSPManager.slnx -c Release` — 0 errors
- [x] `dotnet test … --filter "Category!=LongRunning"` — 71/71 passing
- [x] Pack smoke test: `dotnet pack Umbraco.Community.CSPManager.csproj -p:Version=17.0.0` produces a `.nupkg` with `<version>17.0.0</version>`
- [x] Pack smoke test: `dotnet pack Umbraco.Community.CSPManager.uSync.csproj -p:Version=17.0.0 -p:UseProjectReferences=false` produces a `.nupkg` declaring `<dependency id="Umbraco.Community.CSPManager" version="[17.0.0-0, 18.0.0)" />`
- [ ] CI on this PR: `csp-manager.yml` build job and `usync.yml` build job both green
- [ ] After merge: cut releases in order (CSP Manager release → `usync-17.0.0` tag → `usync-complete-17.0.0` tag) and verify all three appear on NuGet.org

## Notes

- `NU5104` ("stable release should not have a prerelease dependency") is emitted for the `[17.0.0-0, …)` ranges. This is the same warning the previous beta releases produced and is intentional per CLAUDE.md — the `-0` lower bound exists so consumers can pick up future betas during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)