### PR TITLE
fix(release): use stable lower bound in cross-package version ranges

### DIFF
--- a/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Umbraco.Community.CSPManager.uSync.Complete.csproj
+++ b/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Umbraco.Community.CSPManager.uSync.Complete.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="..\Umbraco.Community.CSPManager.uSync\Umbraco.Community.CSPManager.uSync.csproj"
                       Condition="'$(UseProjectReferences)' == 'true'" />
     <PackageReference Include="Umbraco.Community.CSPManager.uSync"
-                      VersionOverride="[17.0.0-0, 18.0.0)"
+                      VersionOverride="[17.0.0, 18.0.0)"
                       Condition="'$(UseProjectReferences)' != 'true'" />
   </ItemGroup>
 

--- a/src/uSync/Umbraco.Community.CSPManager.uSync/Umbraco.Community.CSPManager.uSync.csproj
+++ b/src/uSync/Umbraco.Community.CSPManager.uSync/Umbraco.Community.CSPManager.uSync.csproj
@@ -27,7 +27,7 @@
     <ProjectReference Include="..\..\Umbraco.Community.CSPManager\Umbraco.Community.CSPManager.csproj"
                       Condition="'$(UseProjectReferences)' == 'true'" />
     <PackageReference Include="Umbraco.Community.CSPManager"
-                      VersionOverride="[17.0.0-0, 18.0.0)"
+                      VersionOverride="[17.0.0, 18.0.0)"
                       Condition="'$(UseProjectReferences)' != 'true'">
       <ExcludeAssets>buildTransitive;build</ExcludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

The `usync-17.0.0` release attempt failed at the NuGet publish step:

> error: Response status code does not indicate success: 400 (The NuGet package contains an invalid .nuspec file. The error encountered was: 'The package manifest contains an invalid Version: '17.0.0-0''. Correct the error and try again.)

NuGet.org's server-side validator rejects `17.0.0-0` as an invalid Version literal in dependency ranges, even though the local .NET SDK packs it without complaint. The change introduced in #115 was based on a CLAUDE.md note that turns out to be aspirational, not validated against the publish endpoint.

This PR reverts both `VersionOverride` lines to a stable `[17.0.0, 18.0.0)` lower bound so the upload validates server-side. Pre-release 17.x consumers (which only existed as our own published betas) will no longer satisfy the dependency, which is fine now that 17.0.0 stable is on NuGet.org.

After this lands, the recovery path is:
1. Delete the failed `usync-17.0.0` tag (no package was published, so safe to recycle).
2. Re-tag from new main HEAD and push to re-trigger `release-usync`.
3. Once uSync 17.0.0 publishes, push `usync-complete-17.0.0`.

## Test plan

- [x] `dotnet pack Umbraco.Community.CSPManager.uSync.csproj -p:Version=17.0.0 -p:UseProjectReferences=false` produces a `.nupkg` declaring `<dependency id="Umbraco.Community.CSPManager" version="[17.0.0, 18.0.0)" />`
- [ ] CI build passes on this PR
- [ ] After merge: `usync-17.0.0` re-tag → `release-usync` job → uSync 17.0.0 visible on NuGet.org
- [ ] After uSync publishes: `usync-complete-17.0.0` tag → uSync.Complete 17.0.0 visible on NuGet.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)