### PR TITLE
feat(logging): add diagnostic logs for CSP middleware paths

### DIFF
--- a/src/Umbraco.Community.CSPManager/Logging/Log.cs
+++ b/src/Umbraco.Community.CSPManager/Logging/Log.cs
@@ -22,6 +22,37 @@ internal static partial class Log
 		Message = "Failed to construct CSP header for {Path}")]
 	public static partial void CspHeaderConstructionFailed(ILogger logger, PathString path, Exception ex);
 
+	[LoggerMessage(
+		EventId = 2,
+		Level = LogLevel.Debug,
+		Message = "CSP Header definition disabled for {DefinitionId}")]
+	public static partial void CspDefinitionDisabled(ILogger logger, Guid? definitionId);
+
+
+	[LoggerMessage(
+		EventId = 3,
+		Level = LogLevel.Debug,
+		Message = "Back-office CSP header disabled via config")]
+	public static partial void CspBackOfficeDisabled(ILogger logger);
+
+	[LoggerMessage(
+		EventId = 4,
+		Level = LogLevel.Debug,
+		Message = "CSP header is empty for {DefinitionId}")]
+	public static partial void CspHeaderEmpty(ILogger logger, Guid definitionId);
+
+	[LoggerMessage(
+		EventId = 5,
+		Level = LogLevel.Debug,
+		Message = "CSP OnStarting callback fired for {Path}")]
+	public static partial void CspOnStartingFired(ILogger logger, PathString path);
+
+	[LoggerMessage(
+		EventId = 6,
+		Level = LogLevel.Debug,
+		Message = "CSP header {HeaderName} applied for {DefinitionId} ({Length} chars)")]
+	public static partial void CspHeaderApplied(ILogger logger, string headerName, Guid definitionId, int length);
+
 	// ===========================================
 	// Service Events (100-199)
 	// ===========================================

--- a/src/Umbraco.Community.CSPManager/Middleware/CspMiddleware.cs
+++ b/src/Umbraco.Community.CSPManager/Middleware/CspMiddleware.cs
@@ -90,11 +90,14 @@ public class CspMiddleware
 		{
 			try
 			{
+				Log.CspOnStartingFired(_logger, context.Request.Path);
+
 				var isBackOfficeRequest = context.Request.IsBackOfficeRequest() ||
 					context.Request.Path.StartsWithSegments("/umbraco");
 
 				if (isBackOfficeRequest && _cspOptions.DisableBackOfficeHeader)
 				{
+					Log.CspBackOfficeDisabled(_logger);
 					return;
 				}
 
@@ -103,6 +106,7 @@ public class CspMiddleware
 
 				if (definition is not { Enabled: true })
 				{
+					Log.CspDefinitionDisabled(_logger, definition?.Id);
 					return;
 				}
 
@@ -111,10 +115,16 @@ public class CspMiddleware
 
 				if (!string.IsNullOrWhiteSpace(cspValue))
 				{
-					context.Response.Headers.Append(definition.ReportOnly ? Constants.ReportOnlyHeaderName : Constants.HeaderName, cspValue);
+					var headerName = definition.ReportOnly ? Constants.ReportOnlyHeaderName : Constants.HeaderName;
+					context.Response.Headers.Append(headerName, cspValue);
+					Log.CspHeaderApplied(_logger, headerName, definition.Id, cspValue.Length);
+				}
+				else
+				{
+					Log.CspHeaderEmpty(_logger, definition.Id);
 				}
 			}
-			catch (Exception ex)
+			catch (Exception ex) when (ex is not OperationCanceledException)
 			{
 				// CSP header injection should never break the request.
 				// Log the error and continue without the CSP header.


### PR DESCRIPTION
## Summary

- Add Debug-level logs at every silent-skip path in `CspMiddleware` (backoffice disabled, definition disabled/missing, empty header) plus the success path, so users can diagnose missing CSP headers without instrumenting the middleware themselves.
- Add `CspOnStartingFired` entry log to confirm the `OnStarting` callback is firing per request — the most common silent-failure mode.
- Add `CspHeaderApplied` success log (header name + length) so users can distinguish "we wrote the header" from "downstream stripped it."
- Filter `OperationCanceledException` out of the error catch so client disconnects no longer log as Error.

Motivated by https://forum.umbraco.com/t/csp-manager-not-doing-anything/8216 — the existing logs only confirmed the cache resolution, leaving every silent-return path unobservable.

## Diagnostic decision tree (Debug log level)

| Log seen | Conclusion |
|---|---|
| `CspOnStartingFired` missing | Response committed before `OnStarting` ran — middleware-ordering issue downstream |
| `CspBackOfficeDisabled` | URL classified as backoffice + `DisableBackOfficeHeader` set |
| `CspDefinitionDisabled` | Definition `Enabled=false` (DB state or `CspWritingNotification` handler mutation) |
| `CspHeaderEmpty` | Definition has no usable sources/directives |
| `CspHeaderApplied` fires but browser sees nothing | Downstream strips/replaces — proxy, CDN, IIS rewrite, or other middleware |

## Test plan

- [x] Build passes (`dotnet build`)
- [x] Existing middleware tests still pass
- [x] Manually verify each log fires by configuring its trigger condition on TestSite

🤖 Generated with [Claude Code](https://claude.com/claude-code)