### PR TITLE
chore(ci): unify package releases into a single workflow

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -1,0 +1,72 @@
+name: Publish package
+description: >-
+  Download a packed NuGet artifact, attest its provenance, publish it to
+  NuGet.org via trusted publishing, then create a package-scoped git tag and a
+  titled GitHub Release. Runs inline in the calling job, so it inherits that
+  job's environment and id-token permissions (keeping the NuGet trusted-publishing
+  OIDC context unchanged vs. a per-package job).
+
+inputs:
+  artifact:
+    description: Name of the uploaded package artifact to publish.
+    required: true
+  version:
+    description: Version being released (e.g. 18.0.0-beta-1).
+    required: true
+  tag-prefix:
+    description: Package-scoped git tag prefix (e.g. csp-manager -> csp-manager-18.0.0).
+    required: true
+  title:
+    description: Display name used in the GitHub Release title (e.g. "CSP Manager").
+    required: true
+  prerelease:
+    description: Set to true to mark the GitHub Release as a pre-release.
+    required: true
+  github-token:
+    description: Token used to create the tag and GitHub Release.
+    required: true
+  nuget-user:
+    description: NuGet.org user for trusted-publishing login.
+    required: false
+    default: MattWise
+
+runs:
+  using: composite
+  steps:
+    - name: Download package
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifact }}
+        path: ./build-out/
+
+    - name: Attest build provenance
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: './build-out/*.nupkg'
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: 10.0.x
+
+    - name: NuGet login
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: ${{ inputs.nuget-user }}
+
+    - name: Publish to NuGet
+      shell: bash
+      run: dotnet nuget push ./build-out/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+    - name: Tag and create GitHub Release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        gh release create "${{ inputs.tag-prefix }}-${{ inputs.version }}" \
+          --repo "${{ github.repository }}" \
+          --target "${{ github.sha }}" \
+          --title "${{ inputs.title }} ${{ inputs.version }}" \
+          --generate-notes \
+          ${{ inputs.prerelease == 'true' && '--prerelease' || '' }}

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -46,8 +46,6 @@ runs:
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: 10.0.x
 
     - name: NuGet login
       uses: NuGet/login@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,8 +70,6 @@ jobs:
       #   uses: actions/setup-example@v1
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 10.0.x
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/csp-manager.yml
+++ b/.github/workflows/csp-manager.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 10.0.x
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/csp-manager.yml
+++ b/.github/workflows/csp-manager.yml
@@ -1,8 +1,9 @@
 name: CSP Manager Build
 
+# Build + test validation for the main package on push/PR.
+# Releases are handled by release.yml (Actions -> Release -> Run workflow).
+
 on:
-  release:
-    types: [published]
   push:
     branches:
       - main
@@ -26,7 +27,6 @@ on:
 
 jobs:
   build:
-    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'usync-')
     permissions:
       contents: read
       pull-requests: write
@@ -36,7 +36,7 @@ jobs:
       PROJECT: "./src/Umbraco.Community.CSPManager/Umbraco.Community.CSPManager.csproj"
       TESTPROJECT: "./src/Umbraco.Community.CSPManager.Tests/Umbraco.Community.CSPManager.Tests.csproj"
       TESTLOGPATH: "./src/Umbraco.Community.CSPManager.Tests/TestResults/"
-      BUILD_VERSION: ${{ github.event.release.tag_name || '0.0.0' }}
+      BUILD_VERSION: "0.0.0-ci.${{ github.run_number }}"
       OUT_FOLDER: ./build-out/
 
     runs-on: ubuntu-latest
@@ -88,39 +88,3 @@ jobs:
         with:
           name: nuget-packages
           path: ${{env.OUT_FOLDER}}
-
-  release:
-    needs: build
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    environment: nuget-csp
-    permissions:
-      id-token: write
-      attestations: write
-      contents: read
-
-    steps:
-      - name: Download nuget packages
-        uses: actions/download-artifact@v4
-        with:
-          name: nuget-packages
-          path: ./build-out/
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: './build-out/*.nupkg'
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 10.0.x
-
-      - name: NuGet login
-        uses: NuGet/login@v1
-        id: nuget-login
-        with:
-          user: MattWise
-
-      - name: Publish to NuGet
-        run: dotnet nuget push ./build-out/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,6 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 10.0.x
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,209 @@
+name: Release
+
+# One button to release any (or all) of the three packages.
+#   Actions -> Release -> Run workflow -> pick package + version.
+#
+# Each package is versioned, tagged and released independently, so a patch to
+# one package never forces a re-release of the others. When "all" is selected
+# the packages are packed in dependency order (main -> uSync -> uSync.Complete)
+# against a local NuGet feed, so a brand-new version resolves without waiting
+# for nuget.org indexing (and without hand-editing prerelease ranges).
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package(s) to release'
+        type: choice
+        default: all
+        options:
+          - all
+          - csp-manager
+          - usync
+          - usync-complete
+      version:
+        description: 'Version, e.g. 18.0.0 or 18.0.0-beta-1'
+        type: string
+        required: true
+
+env:
+  MAIN_PROJECT: "./src/Umbraco.Community.CSPManager/Umbraco.Community.CSPManager.csproj"
+  USYNC_PROJECT: "./src/uSync/Umbraco.Community.CSPManager.uSync/Umbraco.Community.CSPManager.uSync.csproj"
+  COMPLETE_PROJECT: "./src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Umbraco.Community.CSPManager.uSync.Complete.csproj"
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Build + pack everything selected, in dependency order, into per-package
+  # artifacts. No environment / no secrets here — this job never publishes.
+  # ---------------------------------------------------------------------------
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      prerelease: ${{ steps.meta.outputs.prerelease }}
+      matrix: ${{ steps.meta.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: './src/Umbraco.Community.CSPManager/Client/package.json'
+          cache: 'npm'
+          cache-dependency-path: |
+            ./src/Umbraco.Community.CSPManager/Client/package-lock.json
+            ./src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client/package-lock.json
+
+      - name: Compute release metadata
+        id: meta
+        run: |
+          VERSION="${{ inputs.version }}"
+          MAJOR="${VERSION%%.*}"
+          CEILING="$((MAJOR + 1)).0.0"
+          if [[ "$VERSION" == *-* ]]; then
+            # Prerelease: floor at the exact version so dependents (and consumers)
+            # resolve the prerelease, not an older stable in the same major.
+            FLOOR="$VERSION"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            # Stable: float across the whole major line.
+            FLOOR="${MAJOR}.0.0"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "floor=$FLOOR" >> "$GITHUB_OUTPUT"
+          echo "ceiling=$CEILING" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION | Dependency range: [$FLOOR,$CEILING)"
+
+          # Emit the publish matrix — only the selected package(s). Each entry drives
+          # one leg of the single publish job (its own environment, tag, release title).
+          CSP='{"artifact":"package-csp","environment":"nuget-csp","tag_prefix":"csp-manager","title":"CSP Manager"}'
+          USYNC='{"artifact":"package-usync","environment":"nuget-usync","tag_prefix":"usync","title":"uSync"}'
+          COMPLETE='{"artifact":"package-complete","environment":"nuget-usync-complete","tag_prefix":"usync-complete","title":"uSync Complete"}'
+          case "${{ inputs.package }}" in
+            all)            ENTRIES="$CSP,$USYNC,$COMPLETE" ;;
+            csp-manager)    ENTRIES="$CSP" ;;
+            usync)          ENTRIES="$USYNC" ;;
+            usync-complete) ENTRIES="$COMPLETE" ;;
+          esac
+          echo "matrix={\"include\":[$ENTRIES]}" >> "$GITHUB_OUTPUT"
+
+      # --- CSP Manager (main) ---
+      - name: Pack CSP Manager
+        if: inputs.package == 'all' || inputs.package == 'csp-manager'
+        run: dotnet pack "$MAIN_PROJECT" -c Release -p:Version=${{ inputs.version }} --output ./build-out/csp
+
+      # --- uSync (depends on main) ---
+      - name: Register CSP Manager as a local feed
+        if: inputs.package == 'all'
+        run: dotnet nuget add source "$(pwd)/build-out/csp" -n local-csp
+
+      - name: Pack uSync
+        if: inputs.package == 'all' || inputs.package == 'usync'
+        run: >-
+          dotnet pack "$USYNC_PROJECT" -c Release
+          -p:Version=${{ inputs.version }}
+          -p:UseProjectReferences=false
+          -p:CspManagerDependencyFloor=${{ steps.meta.outputs.floor }}
+          -p:CspManagerDependencyCeiling=${{ steps.meta.outputs.ceiling }}
+          --output ./build-out/usync
+
+      # --- uSync.Complete (depends on uSync -> main) ---
+      - name: Register uSync as a local feed
+        if: inputs.package == 'all'
+        run: dotnet nuget add source "$(pwd)/build-out/usync" -n local-usync
+
+      - name: Pack uSync Complete
+        if: inputs.package == 'all' || inputs.package == 'usync-complete'
+        run: >-
+          dotnet pack "$COMPLETE_PROJECT" -c Release
+          -p:Version=${{ inputs.version }}
+          -p:UseProjectReferences=false
+          -p:CspManagerDependencyFloor=${{ steps.meta.outputs.floor }}
+          -p:CspManagerDependencyCeiling=${{ steps.meta.outputs.ceiling }}
+          --output ./build-out/complete
+
+      - name: Upload CSP Manager package
+        if: inputs.package == 'all' || inputs.package == 'csp-manager'
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-csp
+          path: ./build-out/csp/
+          if-no-files-found: error
+
+      - name: Upload uSync package
+        if: inputs.package == 'all' || inputs.package == 'usync'
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-usync
+          path: ./build-out/usync/
+          if-no-files-found: error
+
+      - name: Upload uSync Complete package
+        if: inputs.package == 'all' || inputs.package == 'usync-complete'
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-complete
+          path: ./build-out/complete/
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # One publish job, fanned out over the selected packages via a dynamic matrix.
+  # Each leg keeps its own environment (so its NuGet trusted-publishing policy is
+  # unchanged) and creates a package-scoped tag + titled GitHub Release only after
+  # a successful push. fail-fast: false so one package failing doesn't cancel the
+  # others mid-release.
+  # ---------------------------------------------------------------------------
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
+    environment: ${{ matrix.environment }}
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
+    steps:
+      - name: Download package
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ./build-out/
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: './build-out/*.nupkg'
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: MattWise
+
+      - name: Publish to NuGet
+        run: dotnet nuget push ./build-out/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Tag and create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ matrix.tag_prefix }}-${{ inputs.version }}" \
+            --repo "${{ github.repository }}" \
+            --target "${{ github.sha }}" \
+            --title "${{ matrix.title }} ${{ inputs.version }}" \
+            --generate-notes \
+            ${{ needs.build.outputs.prerelease == 'true' && '--prerelease' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,6 @@ jobs:
       contents: read
     outputs:
       prerelease: ${{ steps.meta.outputs.prerelease }}
-      matrix: ${{ steps.meta.outputs.matrix }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -80,19 +79,6 @@ jobs:
           echo "floor=$FLOOR" >> "$GITHUB_OUTPUT"
           echo "ceiling=$CEILING" >> "$GITHUB_OUTPUT"
           echo "Version: $VERSION | Dependency range: [$FLOOR,$CEILING)"
-
-          # Emit the publish matrix — only the selected package(s). Each entry drives
-          # one leg of the single publish job (its own environment, tag, release title).
-          CSP='{"artifact":"package-csp","environment":"nuget-csp","tag_prefix":"csp-manager","title":"CSP Manager"}'
-          USYNC='{"artifact":"package-usync","environment":"nuget-usync","tag_prefix":"usync","title":"uSync"}'
-          COMPLETE='{"artifact":"package-complete","environment":"nuget-usync-complete","tag_prefix":"usync-complete","title":"uSync Complete"}'
-          case "${{ inputs.package }}" in
-            all)            ENTRIES="$CSP,$USYNC,$COMPLETE" ;;
-            csp-manager)    ENTRIES="$CSP" ;;
-            usync)          ENTRIES="$USYNC" ;;
-            usync-complete) ENTRIES="$COMPLETE" ;;
-          esac
-          echo "matrix={\"include\":[$ENTRIES]}" >> "$GITHUB_OUTPUT"
 
       # --- CSP Manager (main) ---
       - name: Pack CSP Manager
@@ -154,56 +140,73 @@ jobs:
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
-  # One publish job, fanned out over the selected packages via a dynamic matrix.
-  # Each leg keeps its own environment (so its NuGet trusted-publishing policy is
-  # unchanged) and creates a package-scoped tag + titled GitHub Release only after
-  # a successful push. fail-fast: false so one package failing doesn't cancel the
-  # others mid-release.
+  # One publish job per package. Each keeps its own environment (so its NuGet
+  # trusted-publishing policy is unchanged) and delegates the download -> attest
+  # -> push -> tag/release steps to the shared ./.github/actions/publish-package
+  # composite, so the logic lives in one place.
   # ---------------------------------------------------------------------------
-  publish:
+  publish-csp:
     needs: build
+    if: inputs.package == 'all' || inputs.package == 'csp-manager'
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.build.outputs.matrix) }}
-    environment: ${{ matrix.environment }}
+    environment: nuget-csp
     permissions:
       id-token: write
       attestations: write
       contents: write
     steps:
-      - name: Download package
-        uses: actions/download-artifact@v4
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Publish CSP Manager
+        uses: ./.github/actions/publish-package
         with:
-          name: ${{ matrix.artifact }}
-          path: ./build-out/
+          artifact: package-csp
+          version: ${{ inputs.version }}
+          tag-prefix: csp-manager
+          title: CSP Manager
+          prerelease: ${{ needs.build.outputs.prerelease }}
+          github-token: ${{ github.token }}
 
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+  publish-usync:
+    needs: build
+    if: inputs.package == 'all' || inputs.package == 'usync'
+    runs-on: ubuntu-latest
+    environment: nuget-usync
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Publish uSync
+        uses: ./.github/actions/publish-package
         with:
-          subject-path: './build-out/*.nupkg'
+          artifact: package-usync
+          version: ${{ inputs.version }}
+          tag-prefix: usync
+          title: uSync
+          prerelease: ${{ needs.build.outputs.prerelease }}
+          github-token: ${{ github.token }}
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+  publish-complete:
+    needs: build
+    if: inputs.package == 'all' || inputs.package == 'usync-complete'
+    runs-on: ubuntu-latest
+    environment: nuget-usync-complete
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Publish uSync Complete
+        uses: ./.github/actions/publish-package
         with:
-          dotnet-version: 10.0.x
-
-      - name: NuGet login
-        uses: NuGet/login@v1
-        id: nuget-login
-        with:
-          user: MattWise
-
-      - name: Publish to NuGet
-        run: dotnet nuget push ./build-out/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-
-      - name: Tag and create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create "${{ matrix.tag_prefix }}-${{ inputs.version }}" \
-            --repo "${{ github.repository }}" \
-            --target "${{ github.sha }}" \
-            --title "${{ matrix.title }} ${{ inputs.version }}" \
-            --generate-notes \
-            ${{ needs.build.outputs.prerelease == 'true' && '--prerelease' || '' }}
+          artifact: package-complete
+          version: ${{ inputs.version }}
+          tag-prefix: usync-complete
+          title: uSync Complete
+          prerelease: ${{ needs.build.outputs.prerelease }}
+          github-token: ${{ github.token }}

--- a/.github/workflows/usync.yml
+++ b/.github/workflows/usync.yml
@@ -1,5 +1,8 @@
 name: uSync Build
 
+# Build + pack validation for the uSync packages on push/PR.
+# Releases are handled by release.yml (Actions -> Release -> Run workflow).
+
 on:
   push:
     branches:
@@ -9,9 +12,6 @@ on:
       - 'src/Directory.Build.props'
       - 'src/Directory.Packages.props'
       - '.github/workflows/usync.yml'
-    tags:
-      - 'usync-*'
-      - 'usync-complete-*'
   pull_request:
     branches:
       - main
@@ -25,6 +25,7 @@ env:
   USYNC_PROJECT: "./src/uSync/Umbraco.Community.CSPManager.uSync/Umbraco.Community.CSPManager.uSync.csproj"
   COMPLETE_PROJECT: "./src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Umbraco.Community.CSPManager.uSync.Complete.csproj"
   OUT_FOLDER: ./build-out/
+  BUILD_VERSION: "0.0.0-ci.${{ github.run_number }}"
 
 jobs:
   build:
@@ -58,122 +59,13 @@ jobs:
         working-directory: ./src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client
 
       - name: Build & Pack uSync
-        run: dotnet pack ${{ env.USYNC_PROJECT }} -c Release -p:Version=0.0.0 --output ${{ env.OUT_FOLDER }}
+        run: dotnet pack ${{ env.USYNC_PROJECT }} -c Release -p:Version=$BUILD_VERSION --output ${{ env.OUT_FOLDER }}
 
       - name: Build & Pack uSync Complete
-        run: dotnet pack ${{ env.COMPLETE_PROJECT }} -c Release -p:Version=0.0.0 --output ${{ env.OUT_FOLDER }}
+        run: dotnet pack ${{ env.COMPLETE_PROJECT }} -c Release -p:Version=$BUILD_VERSION --output ${{ env.OUT_FOLDER }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: uSync Build Output
           path: ${{ env.OUT_FOLDER }}
-
-  release-usync:
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/usync-') && !startsWith(github.ref, 'refs/tags/usync-complete-')
-    runs-on: ubuntu-latest
-    environment: nuget-usync
-    permissions:
-      id-token: write
-      attestations: write
-      contents: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/usync-}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION"
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 10.0.x
-
-      - name: Build & Pack
-        run: dotnet pack ${{ env.USYNC_PROJECT }} -c Release -p:Version=${{ steps.version.outputs.version }} -p:UseProjectReferences=false --output ${{ env.OUT_FOLDER }}
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: '${{ env.OUT_FOLDER }}*.nupkg'
-
-      - name: NuGet login
-        uses: NuGet/login@v1
-        id: nuget-login
-        with:
-          user: MattWise
-
-      - name: Publish to NuGet
-        run: |
-          for package in ${{ env.OUT_FOLDER }}*.nupkg; do
-            echo "Publishing $package"
-            dotnet nuget push "$package" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-          done
-
-  release-usync-complete:
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/usync-complete-')
-    runs-on: ubuntu-latest
-    environment: nuget-usync-complete
-    permissions:
-      id-token: write
-      attestations: write
-      contents: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/usync-complete-}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION"
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 10.0.x
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: './src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client/package.json'
-          cache: 'npm'
-          cache-dependency-path: './src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client/package-lock.json'
-
-      - name: Install client dependencies
-        run: npm ci
-        working-directory: ./src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client
-
-      - name: Build client
-        run: npm run build
-        working-directory: ./src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client
-
-      - name: Build & Pack
-        run: dotnet pack ${{ env.COMPLETE_PROJECT }} -c Release -p:Version=${{ steps.version.outputs.version }} -p:UseProjectReferences=false --output ${{ env.OUT_FOLDER }}
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: '${{ env.OUT_FOLDER }}*.nupkg'
-
-      - name: NuGet login
-        uses: NuGet/login@v1
-        id: nuget-login
-        with:
-          user: MattWise
-
-      - name: Publish to NuGet
-        run: |
-          for package in ${{ env.OUT_FOLDER }}*.nupkg; do
-            echo "Publishing $package"
-            dotnet nuget push "$package" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-          done

--- a/.github/workflows/usync.yml
+++ b/.github/workflows/usync.yml
@@ -40,8 +40,6 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 10.0.x
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,15 +27,46 @@ src/
 - Testing: NUnit (backend), Playwright (frontend)
 - API: OpenAPI code generation via @hey-api/openapi-ts
 
-## CI Release Tags
+## Releasing
 
 All packages use major version aligned to Umbraco (e.g. Umbraco 18 → `18.x.x`).
 
-- CSP Manager: GitHub Release tag `18.0.0` (triggers `csp-manager.yml`)
-- uSync: git tag `usync-18.0.0` (triggers `usync.yml` `release-usync` job)
-- uSync Complete: git tag `usync-complete-18.0.0` (triggers `usync.yml` `release-usync-complete` job)
+Single entry point: **Actions → Release → Run workflow** (`release.yml`). Pick the
+`package` (`all` / `csp-manager` / `usync` / `usync-complete`) and a `version`
+(e.g. `18.0.0` or `18.0.0-beta-1`). Each package is packed, pushed to NuGet, and
+gets its own tag + titled GitHub Release:
 
-Each package releases independently. Dependencies use a version range `[18.0.0, 19.0.0)` — accepts any 18.x. Only update the lower bound in the `.csproj` when a dependency has a breaking change that requires a newer minimum.
+- CSP Manager → tag `csp-manager-<version>`, release "CSP Manager <version>"
+- uSync → tag `usync-<version>`, release "uSync <version>"
+- uSync Complete → tag `usync-complete-<version>`, release "uSync Complete <version>"
+
+`all` packs in dependency order (main → uSync → uSync.Complete) against a local
+NuGet feed, so a brand-new version resolves without waiting for nuget.org indexing.
+Each package still releases independently — patch one without re-releasing the others
+by selecting just that package.
+
+`csp-manager.yml` / `usync.yml` now only run build + test on push/PR. They pack a
+unique prerelease version `0.0.0-ci.<run_number>` and upload the `.nupkg`s as
+artifacts (`nuget-packages` / `uSync Build Output`) so a build can be tested before
+merge — the unique version stops NuGet serving a stale cached `0.0.0`:
+
+```
+gh run download <run-id> -n nuget-packages
+dotnet nuget add source ./<downloaded-folder> -n pr-test
+dotnet add package Umbraco.Community.CSPManager -v 0.0.0-ci.<run_number> --prerelease
+```
+
+**Dependency range:** the supporting packages declare `[18.0.0, 19.0.0)` for their
+internal CSP Manager dependencies, assembled in `src/Directory.Build.props` from
+`CspManagerDependencyFloor` (`18.0.0`) and `CspManagerDependencyCeiling` (`19.0.0`).
+Bump the floor only on a breaking change that requires a newer minimum. The release
+workflow overrides the floor to the exact version for prerelease builds (e.g.
+`[18.0.0-beta-1, 19.0.0)`) — no manual csproj edits for betas. Floor/ceiling are
+separate (no commas) because .NET's `-p:` parser splits property values on commas.
+
+**NuGet trusted publishing:** each package's policy must reference workflow
+`release.yml` (environments `nuget-csp` / `nuget-usync` / `nuget-usync-complete`
+are unchanged).
 
 ## Development Principles
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestMinor"
+  }
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,18 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Version range the supporting packages (uSync, uSync.Complete) declare for their
+         internal CSP Manager dependencies. Single source of truth: bump the floor only
+         when a dependency has a breaking change that requires a newer minimum.
+         Floor + ceiling are kept as separate properties (no commas) so the release
+         workflow can override them on the command line — .NET's -p: parser splits
+         values on commas, so the assembled range can't be passed directly. The
+         workflow sets a prerelease floor (e.g. 18.0.0-beta-1) for prerelease builds. -->
+    <CspManagerDependencyFloor Condition="'$(CspManagerDependencyFloor)' == ''">18.0.0</CspManagerDependencyFloor>
+    <CspManagerDependencyCeiling Condition="'$(CspManagerDependencyCeiling)' == ''">19.0.0</CspManagerDependencyCeiling>
+    <CspManagerDependencyRange>[$(CspManagerDependencyFloor),$(CspManagerDependencyCeiling))</CspManagerDependencyRange>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\images\icon.png" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>

--- a/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/CLAUDE.md
+++ b/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/CLAUDE.md
@@ -20,7 +20,9 @@ Extends the base uSync integration with Push/Pull capabilities for cross-environ
 
 - Default: `ProjectReference` to CSPManager.uSync (dev)
 - NuGet pack: `dotnet pack -p:UseProjectReferences=false` switches to `PackageReference`
-- Version range: `[18.0.0, 19.0.0)` — accepts any 18.x
+- Version range: `$(CspManagerDependencyRange)`, defined in `src/Directory.Build.props`
+  (default `[18.0.0, 19.0.0)` — accepts any 18.x). The release workflow overrides it
+  for prerelease builds; bump `CspManagerDependencyFloor`, not this csproj, on a breaking change.
 
 ## Test Sites
 

--- a/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Umbraco.Community.CSPManager.uSync.Complete.csproj
+++ b/src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Umbraco.Community.CSPManager.uSync.Complete.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="..\Umbraco.Community.CSPManager.uSync\Umbraco.Community.CSPManager.uSync.csproj"
                       Condition="'$(UseProjectReferences)' == 'true'" />
     <PackageReference Include="Umbraco.Community.CSPManager.uSync"
-                      VersionOverride="[18.0.0, 19.0.0)"
+                      VersionOverride="$(CspManagerDependencyRange)"
                       Condition="'$(UseProjectReferences)' != 'true'" />
   </ItemGroup>
 

--- a/src/uSync/Umbraco.Community.CSPManager.uSync/CLAUDE.md
+++ b/src/uSync/Umbraco.Community.CSPManager.uSync/CLAUDE.md
@@ -13,7 +13,9 @@ Provides uSync serialization and sync support for CSP Manager configurations.
 
 - Default: `ProjectReference` to CSPManager (instant change flow during development)
 - NuGet pack: `dotnet pack -p:UseProjectReferences=false` switches to `PackageReference`
-- Version range: `[18.0.0, 19.0.0)` — accepts any 18.x
+- Version range: `$(CspManagerDependencyRange)`, defined in `src/Directory.Build.props`
+  (default `[18.0.0, 19.0.0)` — accepts any 18.x). The release workflow overrides it
+  for prerelease builds; bump `CspManagerDependencyFloor`, not this csproj, on a breaking change.
 
 ## Key Behaviors
 

--- a/src/uSync/Umbraco.Community.CSPManager.uSync/Umbraco.Community.CSPManager.uSync.csproj
+++ b/src/uSync/Umbraco.Community.CSPManager.uSync/Umbraco.Community.CSPManager.uSync.csproj
@@ -27,7 +27,7 @@
     <ProjectReference Include="..\..\Umbraco.Community.CSPManager\Umbraco.Community.CSPManager.csproj"
                       Condition="'$(UseProjectReferences)' == 'true'" />
     <PackageReference Include="Umbraco.Community.CSPManager"
-                      VersionOverride="[18.0.0, 19.0.0)"
+                      VersionOverride="$(CspManagerDependencyRange)"
                       Condition="'$(UseProjectReferences)' != 'true'">
       <ExcludeAssets>buildTransitive;build</ExcludeAssets>
     </PackageReference>


### PR DESCRIPTION
## What this does

Consolidates the three separate release mechanisms into **one button**.

**Before:** main released via a published GitHub Release; uSync via a `usync-*` git tag; uSync Complete via a `usync-complete-*` git tag — three actions, in order, often with hand-edited version ranges for prereleases.

**After:** _Actions → Release → Run workflow_ → pick `package` (`all` / `csp-manager` / `usync` / `usync-complete`) + `version`. Each package is still versioned, tagged and released independently.

### Key changes
- **`release.yml`** (new): `workflow_dispatch` release for any/all packages.
  - Packs in dependency order (main → uSync → uSync.Complete) against a **local NuGet feed**, so a brand-new version resolves without waiting for nuget.org indexing.
  - Derives a **prerelease-aware dependency floor** automatically (e.g. `[18.0.0-beta-1, 19.0.0)`) — no more manual csproj edits for betas.
  - Three **separate per-package publish jobs** (each in its own environment), templated via a shared local composite action `.github/actions/publish-package` so the download → attest → push → tag/release logic lives in one place. (Composite over a reusable workflow so the OIDC context stays identical — see below.)
  - Per-package tags + titled GitHub Releases: `csp-manager-<v>` / `usync-<v>` / `usync-complete-<v>`.
- **`Directory.Build.props`**: dependency range centralised into `CspManagerDependencyFloor` (`18.0.0`) + `CspManagerDependencyCeiling` (`19.0.0`); both csprojs now consume `$(CspManagerDependencyRange)`. (Floor/ceiling are separate because .NET's `-p:` parser splits values on commas.)
- **`csp-manager.yml` / `usync.yml`**: reduced to build + test on push/PR. They now pack a unique `0.0.0-ci.<run_number>` and upload the `.nupkg`s so a build can be tested pre-merge (the unique version stops NuGet serving a stale cached `0.0.0`).

---

## ✅ What you need to do

### 1. Reconfigure NuGet trusted publishing (required before the first release)
Each package's trusted-publishing policy on nuget.org currently points at the **old** workflow files. Update all three to reference **`release.yml`**. The environment names are unchanged:

| Package | Workflow (change to) | Environment (unchanged) |
|---|---|---|
| Umbraco.Community.CSPManager | `release.yml` | `nuget-csp` |
| Umbraco.Community.CSPManager.uSync | `release.yml` | `nuget-usync` |
| Umbraco.Community.CSPManager.uSync.Complete | `release.yml` | `nuget-usync-complete` |

> nuget.org → each package → _Settings / Trusted Publishing_ → edit the GitHub Actions policy's workflow file field.

### 2. Merge this PR
`release.yml` only becomes runnable once it's on the default branch.

### 3. First release — `18.0.0-beta-1`
_Actions → Release → Run workflow_ → `package: all`, `version: 18.0.0-beta-1`. This publishes all three, tags them, and creates three pre-release GitHub Releases.

> 💡 Optional dry run first: release just `package: csp-manager` at the beta to confirm the OIDC / trusted-publishing wiring end-to-end before doing `all`.

---

## 🔎 Things to confirm / decide

- **Tag scheme changed for the main package** — it's now `csp-manager-<version>` (was a plain `<version>` tag). This avoids collisions when all three release at the same version. Shout if you'd rather keep the plain tag for main.
- **Supporting-package test packages** — the PR build packs uSync/Complete with the default `ProjectReference` wiring, so those test `.nupkg`s carry unrealistic dependency versions (fine for the **main** package, not for validating uSync/Complete dependency resolution). If you want PR builds to produce genuinely installable supporting packages, I can extend the release job's local-feed pack flow to the CI workflows.
- **Composite action** — the three publish jobs share `.github/actions/publish-package`. It runs inline in each job, so it inherits that job's `environment` and `id-token` permissions and keeps the NuGet trusted-publishing OIDC context identical to a hand-written job (unlike a `workflow_call` reusable workflow, which changes `job_workflow_ref`). Each publish job now checks out the repo so the local action is available.

## Testing a pre-merge build
```
gh run download <run-id> -n nuget-packages          # or "uSync Build Output"
dotnet nuget add source ./<downloaded-folder> -n pr-test
dotnet add package Umbraco.Community.CSPManager -v 0.0.0-ci.<run_number> --prerelease
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
