### PR TITLE
fix(ci): first-release fixes for the unified pipeline

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -62,9 +62,17 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        gh release create "${{ inputs.tag-prefix }}-${{ inputs.version }}" \
-          --repo "${{ github.repository }}" \
-          --target "${{ github.sha }}" \
-          --title "${{ inputs.title }} ${{ inputs.version }}" \
-          --generate-notes \
-          ${{ inputs.prerelease == 'true' && '--prerelease' || '' }}
+        tag="${{ inputs.tag-prefix }}-${{ inputs.version }}"
+        # Idempotent: the package push above uses --skip-duplicate, so a re-run of an
+        # already-published version must not fail here. Releases are immutable (can't be
+        # edited/recreated), so if one already exists for this tag, treat it as done.
+        if gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+          echo "Release $tag already exists — skipping creation."
+        else
+          gh release create "$tag" \
+            --repo "${{ github.repository }}" \
+            --target "${{ github.sha }}" \
+            --title "${{ inputs.title }} ${{ inputs.version }}" \
+            --generate-notes \
+            ${{ inputs.prerelease == 'true' && '--prerelease' || '' }}
+        fi

--- a/.github/workflows/csp-manager.yml
+++ b/.github/workflows/csp-manager.yml
@@ -13,7 +13,10 @@ on:
       - 'src/Umbraco.Community.CSPManager.Benchmarks/**'
       - 'src/Directory.Build.props'
       - 'src/Directory.Packages.props'
+      - 'global.json'
+      - '.github/actions/**'
       - '.github/workflows/csp-manager.yml'
+      - '.github/workflows/release.yml'
   pull_request:
     branches:
       - main
@@ -23,7 +26,10 @@ on:
       - 'src/Umbraco.Community.CSPManager.Benchmarks/**'
       - 'src/Directory.Build.props'
       - 'src/Directory.Packages.props'
+      - 'global.json'
+      - '.github/actions/**'
       - '.github/workflows/csp-manager.yml'
+      - '.github/workflows/release.yml'
 
 jobs:
   build:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,18 @@ NuGet feed, so a brand-new version resolves without waiting for nuget.org indexi
 Each package still releases independently — patch one without re-releasing the others
 by selecting just that package.
 
+**Versions are immutable — never re-release one.** NuGet rejects a duplicate version
+and GitHub releases are immutable, so a published version can't be replaced; to ship a
+change, bump the version (e.g. `18.0.0-beta-1` → `18.0.0-beta-2`). The publish job is
+re-run-safe (NuGet push uses `--skip-duplicate`; the release step skips if the tag
+already exists), so re-running after a *partial* failure completes the missing steps
+without erroring — but it won't overwrite anything already published.
+
+**Deployment environments:** the `workflow_dispatch` runs from `main`, so each
+`nuget-*` environment's protection rules must allow the `main` branch (Settings →
+Environments). The old tag-triggered flow only allowed `usync-*` tags, so this needs
+adding once per environment.
+
 `csp-manager.yml` / `usync.yml` now only run build + test on push/PR. They pack a
 unique prerelease version `0.0.0-ci.<run_number>` and upload the `.nupkg`s as
 artifacts (`nuget-packages` / `uSync Build Output`) so a build can be tested before


### PR DESCRIPTION
Fixes surfaced by the first real run of the unified release pipeline (releasing `18.0.0-beta-1`). All four are release-infrastructure only.

### 1. Idempotent GitHub Release step
The publish job pushed to NuGet successfully but failed on `gh release create` with `HTTP 422: tag_name already exists` (releases are immutable). `dotnet nuget push` already uses `--skip-duplicate`; the release step now skips if a release for the tag already exists, so re-runs after a partial failure complete cleanly.

### 2. Central transitive pinning forced a stable CSP Manager dependency
`Directory.Packages.props` pinned `Umbraco.Community.CSPManager(.uSync)` to a stable `18.0.0` with `CentralPackageTransitivePinningEnabled=true`. Packing **uSync.Complete** against a prerelease, transitive pinning overrode the `[18.0.0-beta-1, 19.0.0)` range in uSync's nuspec and forced the transitive main dependency to `>= 18.0.0` stable → `NU1102` (only `18.0.0-beta-1` exists). Both central versions now point at `$(CspManagerDependencyRange)`, so the pin honours the prerelease floor. (Packing uSync alone was unaffected — main is a direct ref with `VersionOverride` there, which beats central pinning.)

### 3. Required-check / path-filter deadlock
`main` requires a `build` status check, but the `build` workflows are path-filtered and PRs touching only shared CI files (`.github/actions/**`, `global.json`, `release.yml`) triggered no build → blocked forever. Added those paths to `csp-manager.yml` so such PRs run `build`.

### 4. Docs
Documented immutable versions (bump, don't re-release), the re-run-safe publish job, and the `main`-branch environment protection rule.

## Notes
- uSync + CSP Manager `18.0.0-beta-1` are already live on NuGet; trusted publishing is confirmed working.
- **Merge this before re-running** `usync-complete` / `all` — the workflow runs from `main`, so fix #2 must be on `main` or the Complete pack keeps failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)