### PR TITLE
fix(middleware): don't abort the response when a request is cancelled

### DIFF
--- a/src/Umbraco.Community.CSPManager.Tests/Middleware/CspMiddlewareTests.cs
+++ b/src/Umbraco.Community.CSPManager.Tests/Middleware/CspMiddlewareTests.cs
@@ -267,6 +267,84 @@ public class CspMiddlewareTests
 		});
 	}
 
+	[Test]
+	public async Task CspMiddleware_WhenServiceIsCancelled_RequestCompletesWithoutCspHeader()
+	{
+		// Regression test for #130: a TaskCanceledException escaping the OnStarting callback
+		// was reported by Kestrel as "The response has been aborted due to an unhandled
+		// application exception" instead of being swallowed.
+		Mock.Get(_cspService)
+			.Setup(x => x.GetCachedCspDefinitionAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new TaskCanceledException("Request aborted"));
+
+		var logger = new Mock<ILogger<CspMiddleware>>();
+		logger.Setup(x => x.IsEnabled(LogLevel.Debug)).Returns(true);
+
+		using var host = BuildTestHost(extraServices: s => s.AddSingleton(logger.Object));
+
+		var response = await host.GetTestClient().GetAsync("/");
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(response.Headers.Contains(Constants.HeaderName), Is.False);
+			Assert.That(response.Headers.Contains(Constants.ReportOnlyHeaderName), Is.False);
+		});
+
+		logger.Verify(x => x.Log(
+			LogLevel.Debug,
+			It.Is<EventId>(e => e.Name == "CspHeaderCancelled"),
+			It.IsAny<It.IsAnyType>(),
+			null,
+			It.IsAny<Func<It.IsAnyType, Exception, string>>()), Times.Once);
+	}
+
+	[Test]
+	public async Task CspMiddleware_DoesNotCancelDefinitionLoadWhenClientDisconnects()
+	{
+		// The cached definition is shared process-wide, so a per-request abort token must not
+		// be threaded into the load — one client disconnecting would fault it for everyone.
+		CancellationToken observedToken = new(canceled: true);
+		Mock.Get(_cspService)
+			.Setup(x => x.GetCachedCspDefinitionAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+			.Callback<bool, CancellationToken>((_, token) => observedToken = token)
+			.ReturnsAsync(new CspDefinition { Id = Constants.DefaultFrontEndId, Enabled = false });
+
+		await _host.GetTestClient().GetAsync("/");
+
+		Assert.That(observedToken.CanBeCanceled, Is.False,
+			"The definition load must not be tied to the request lifetime.");
+	}
+
+	[Test]
+	public async Task CspMiddleware_WhenDefinitionIsNull_LogsNotFoundRatherThanDisabled()
+	{
+		Mock.Get(_cspService)
+			.Setup(x => x.GetCachedCspDefinitionAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync((CspDefinition)null);
+
+		var logger = new Mock<ILogger<CspMiddleware>>();
+		logger.Setup(x => x.IsEnabled(LogLevel.Debug)).Returns(true);
+
+		using var host = BuildTestHost(extraServices: s => s.AddSingleton(logger.Object));
+
+		var response = await host.GetTestClient().GetAsync("/");
+
+		Assert.That(response.Headers.Contains(Constants.HeaderName), Is.False);
+
+		logger.Verify(x => x.Log(
+			LogLevel.Debug,
+			It.Is<EventId>(e => e.Name == "CspDefinitionNotFound"),
+			It.IsAny<It.IsAnyType>(),
+			null,
+			It.IsAny<Func<It.IsAnyType, Exception, string>>()), Times.Once);
+		logger.Verify(x => x.Log(
+			LogLevel.Debug,
+			It.Is<EventId>(e => e.Name == "CspDefinitionDisabled"),
+			It.IsAny<It.IsAnyType>(),
+			null,
+			It.IsAny<Func<It.IsAnyType, Exception, string>>()), Times.Never);
+	}
+
 	[TearDown]
 	public async Task TearDownAsync()
 	{

--- a/src/Umbraco.Community.CSPManager/Logging/Log.cs
+++ b/src/Umbraco.Community.CSPManager/Logging/Log.cs
@@ -26,7 +26,7 @@ internal static partial class Log
 		EventId = 2,
 		Level = LogLevel.Debug,
 		Message = "CSP Header definition disabled for {DefinitionId}")]
-	public static partial void CspDefinitionDisabled(ILogger logger, Guid? definitionId);
+	public static partial void CspDefinitionDisabled(ILogger logger, Guid definitionId);
 
 
 	[LoggerMessage(
@@ -58,6 +58,18 @@ internal static partial class Log
 		Level = LogLevel.Warning,
 		Message = "A CSP nonce was requested via tag helper but '{Directive}' is not configured in definition {DefinitionId}; the nonce was not added to the CSP header")]
 	public static partial void CspNonceDirectiveMissing(ILogger logger, string directive, Guid definitionId);
+
+	[LoggerMessage(
+		EventId = 8,
+		Level = LogLevel.Debug,
+		Message = "CSP header skipped for {Path}: the request was cancelled before the header could be applied")]
+	public static partial void CspHeaderCancelled(ILogger logger, PathString path);
+
+	[LoggerMessage(
+		EventId = 9,
+		Level = LogLevel.Debug,
+		Message = "No CSP definition was returned for {Context}; no CSP header was applied")]
+	public static partial void CspDefinitionNotFound(ILogger logger, string context);
 
 	// ===========================================
 	// Service Events (100-199)

--- a/src/Umbraco.Community.CSPManager/Middleware/CspMiddleware.cs
+++ b/src/Umbraco.Community.CSPManager/Middleware/CspMiddleware.cs
@@ -101,12 +101,21 @@ public class CspMiddleware
 					return;
 				}
 
-				var definition = await _cspService.GetCachedCspDefinitionAsync(isBackOfficeRequest, context.RequestAborted);
+				// Deliberately not context.RequestAborted: this call populates a process-wide
+				// cache that other in-flight requests await, so one client disconnecting must
+				// not cancel the load and fault the shared entry for everyone else.
+				var definition = await _cspService.GetCachedCspDefinitionAsync(isBackOfficeRequest, CancellationToken.None);
 				await _eventAggregator.PublishAsync(new CspWritingNotification(definition, context));
 
-				if (definition is not { Enabled: true })
+				if (definition is null)
 				{
-					Log.CspDefinitionDisabled(_logger, definition?.Id);
+					Log.CspDefinitionNotFound(_logger, isBackOfficeRequest ? "BackOffice" : "Frontend");
+					return;
+				}
+
+				if (!definition.Enabled)
+				{
+					Log.CspDefinitionDisabled(_logger, definition.Id);
 					return;
 				}
 
@@ -124,7 +133,14 @@ public class CspMiddleware
 					Log.CspHeaderEmpty(_logger, definition.Id);
 				}
 			}
-			catch (Exception ex) when (ex is not OperationCanceledException)
+			catch (OperationCanceledException)
+			{
+				// The client disconnected before the response started, so there is no response
+				// left to add a header to. Rethrowing from OnStarting would surface as an
+				// unhandled application exception and abort the connection.
+				Log.CspHeaderCancelled(_logger, context.Request.Path);
+			}
+			catch (Exception ex)
 			{
 				// CSP header injection should never break the request.
 				// Log the error and continue without the CSP header.


### PR DESCRIPTION
Fixes #130.

## Cause

Two things combined to produce the reported `ObjectDisposedException` on startup:

1. **`CspMiddleware` passed `context.RequestAborted` into `GetCachedCspDefinitionAsync`.** That token flowed through the runtime-cache factory into the NPoco query, so a client disconnecting mid-request cancelled the database read. This arrived in 604988b ("Async CspService and code quality improvements for v17") — the previous sync call took no token, so it couldn't happen before.

2. **The catch filter explicitly excluded `OperationCanceledException`.** `TaskCanceledException` derives from it, so the exception escaped the `Response.OnStarting` callback. Kestrel reports that as an unhandled application exception and aborts the response, which is the `ObjectDisposedException` wrapper in the issue. The comment directly below the filter — *"CSP header injection should never break the request"* — was the invariant the filter broke.

It only reproduces on a cold cache, which explains the intermittent 1-in-5-to-10 startup frequency: once the definition is cached there's no database call left to cancel, and the startup window (connection pool warm-up, Umbraco boot) is where a client is most likely to give up and disconnect.

## Changes

**`CspMiddleware.cs`**

- Load the definition with `CancellationToken.None`. The cached definition is process-wide and other in-flight requests await the same entry, so scoping the load to one client's connection was wrong independently of this crash — request A disconnecting could fault the entry request B was waiting on.
- Give cancellation its own `catch (OperationCanceledException)` that logs and returns. There is no caller to propagate to inside `OnStarting`; rethrowing only aborts the connection. The general `catch (Exception ex)` is now unfiltered.
- Split the null-definition case out of the `Enabled` check, which previously logged `"CSP Header definition disabled for (null)"` when nothing came back at all.

**`Log.cs`** — adds `CspHeaderCancelled` (EventId 8) and `CspDefinitionNotFound` (EventId 9), both `Debug`. `CspDefinitionDisabled` narrows from `Guid?` to `Guid` now that null has its own event.

Both new events are `Debug` rather than `Warning` on purpose. The fix turns a loud failure into a silent one, and "no CSP header was applied" is worth being able to find in a log — but client disconnects are routine, and a warning-level event on that path would be noisier in production than the bug being fixed.

**Tests** — three added to `CspMiddlewareTests`: the `TaskCanceledException` regression (request completes, no header, event logged), an assertion that the token handed to the service isn't cancellable, and the null-vs-disabled logging split.

## Verification

Not built or tested locally — the dev container has no .NET SDK and the network policy blocked installing one. The diff was reviewed by inspection; CI on this branch is the real check, so please confirm the `csp-manager` workflow is green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CskQnK2r3RVBqSjL8CDAm1)_