### PR TITLE
fix(cache): make CSP cache invalidation on save reliable

### DIFF
--- a/src/Umbraco.Community.CSPManager.Tests/Notifications/CspDistributedCacheRefresherTests.cs
+++ b/src/Umbraco.Community.CSPManager.Tests/Notifications/CspDistributedCacheRefresherTests.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Serialization;
-using Umbraco.Cms.Core.Sync;
 using Umbraco.Community.CSPManager.Models;
 using Umbraco.Community.CSPManager.Notifications;
 using Umbraco.Community.CSPManager.Notifications.Handlers;
@@ -13,14 +12,12 @@ namespace Umbraco.Community.CSPManager.Tests.Notifications;
 public class CspDistributedCacheRefresherTests
 {
 	private Mock<IAppPolicyCache> _runtimeCache;
-	private Mock<IServerRoleAccessor> _serverRoleAccessor;
 	private CspDistributedCacheRefresher _refresher;
 
 	[SetUp]
 	public void SetUp()
 	{
 		_runtimeCache = new Mock<IAppPolicyCache>();
-		_serverRoleAccessor = new Mock<IServerRoleAccessor>();
 
 		var appCaches = new AppCaches(
 			_runtimeCache.Object,
@@ -29,7 +26,6 @@ public class CspDistributedCacheRefresherTests
 
 		_refresher = new CspDistributedCacheRefresher(
 			appCaches,
-			_serverRoleAccessor.Object,
 			Mock.Of<IJsonSerializer>(),
 			NullLogger<CspDistributedCacheRefresher>.Instance,
 			Mock.Of<IEventAggregator>(),
@@ -37,9 +33,8 @@ public class CspDistributedCacheRefresherTests
 	}
 
 	[Test]
-	public void Refresh_AsSubscriber_WithBackOfficePayload_ClearsBackOfficeCache()
+	public void Refresh_WithBackOfficePayload_ClearsBackOfficeCache()
 	{
-		_serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(ServerRole.Subscriber);
 		var payload = new[] { new CspSavedNotification(new CspDefinition { IsBackOffice = true }) };
 
 		_refresher.Refresh(payload);
@@ -49,9 +44,8 @@ public class CspDistributedCacheRefresherTests
 	}
 
 	[Test]
-	public void Refresh_AsSubscriber_WithFrontEndPayload_ClearsFrontEndCache()
+	public void Refresh_WithFrontEndPayload_ClearsFrontEndCache()
 	{
-		_serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(ServerRole.Subscriber);
 		var payload = new[] { new CspSavedNotification(new CspDefinition { IsBackOffice = false }) };
 
 		_refresher.Refresh(payload);
@@ -61,34 +55,26 @@ public class CspDistributedCacheRefresherTests
 	}
 
 	[Test]
-	public void Refresh_AsNonSubscriber_DoesNotClearCache()
+	public void Refresh_WithPayloadsForBothContexts_ClearsBothCacheKeys()
 	{
-		_serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(ServerRole.SchedulingPublisher);
-		var payload = new[] { new CspSavedNotification(new CspDefinition { IsBackOffice = true }) };
+		var payload = new[]
+		{
+			new CspSavedNotification(new CspDefinition { IsBackOffice = true }),
+			new CspSavedNotification(new CspDefinition { IsBackOffice = false })
+		};
 
 		_refresher.Refresh(payload);
-
-		_runtimeCache.Verify(c => c.ClearByKey(It.IsAny<string>()), Times.Never);
-	}
-
-	[Test]
-	public void RefreshAll_AsSubscriber_ClearsBothCacheKeys()
-	{
-		_serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(ServerRole.Subscriber);
-
-		_refresher.RefreshAll();
 
 		_runtimeCache.Verify(c => c.ClearByKey(Constants.BackOfficeCacheKey), Times.Once);
 		_runtimeCache.Verify(c => c.ClearByKey(Constants.FrontEndCacheKey), Times.Once);
 	}
 
 	[Test]
-	public void RefreshAll_AsNonSubscriber_DoesNotClearCache()
+	public void RefreshAll_ClearsBothCacheKeys()
 	{
-		_serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(ServerRole.Single);
-
 		_refresher.RefreshAll();
 
-		_runtimeCache.Verify(c => c.ClearByKey(It.IsAny<string>()), Times.Never);
+		_runtimeCache.Verify(c => c.ClearByKey(Constants.BackOfficeCacheKey), Times.Once);
+		_runtimeCache.Verify(c => c.ClearByKey(Constants.FrontEndCacheKey), Times.Once);
 	}
 }

--- a/src/Umbraco.Community.CSPManager.Tests/Notifications/CspSavedNotificationHandlerTests.cs
+++ b/src/Umbraco.Community.CSPManager.Tests/Notifications/CspSavedNotificationHandlerTests.cs
@@ -55,8 +55,6 @@ public class CspSavedNotificationHandlerTests
 		_runtimeCache.Verify(c => c.ClearByKey(Constants.BackOfficeCacheKey), Times.Never);
 	}
 
-	// A save can be handled by any server in a load balanced setup, so the invalidation is broadcast
-	// unconditionally - it is no longer gated on this server being the scheduling publisher.
 	[Test]
 	public void Handle_TriggersDistributedCacheRefresh()
 	{

--- a/src/Umbraco.Community.CSPManager.Tests/Notifications/CspSavedNotificationHandlerTests.cs
+++ b/src/Umbraco.Community.CSPManager.Tests/Notifications/CspSavedNotificationHandlerTests.cs
@@ -1,5 +1,4 @@
 using Umbraco.Cms.Core.Cache;
-using Umbraco.Cms.Core.Sync;
 using Umbraco.Community.CSPManager.Models;
 using Umbraco.Community.CSPManager.Notifications;
 using Umbraco.Community.CSPManager.Notifications.Handlers;
@@ -11,7 +10,6 @@ namespace Umbraco.Community.CSPManager.Tests.Notifications;
 public class CspSavedNotificationHandlerTests
 {
 	private Mock<IAppPolicyCache> _runtimeCache;
-	private Mock<IServerRoleAccessor> _serverRoleAccessor;
 	private CspSavedNotificationHandler _handler;
 	private SpyServerMessenger _serverMessenger;
 
@@ -19,7 +17,6 @@ public class CspSavedNotificationHandlerTests
 	public void SetUp()
 	{
 		_runtimeCache = new Mock<IAppPolicyCache>();
-		_serverRoleAccessor = new Mock<IServerRoleAccessor>();
 		_serverMessenger = new SpyServerMessenger();
 
 		var cacheRefresherCollection = new CacheRefresherCollection(() => new ICacheRefresher[]
@@ -33,14 +30,13 @@ public class CspSavedNotificationHandlerTests
 			Mock.Of<IRequestCache>(),
 			new IsolatedCaches(_ => NoAppCache.Instance));
 
-		_handler = new CspSavedNotificationHandler(_serverRoleAccessor.Object, appCaches, distributedCache);
+		_handler = new CspSavedNotificationHandler(appCaches, distributedCache);
 	}
 
 	[Test]
 	public void Handle_BackOfficeSave_ClearsBackOfficeCacheKey()
 	{
 		var notification = new CspSavedNotification(new CspDefinition { IsBackOffice = true });
-		_serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(ServerRole.Single);
 
 		_handler.Handle(notification);
 
@@ -52,7 +48,6 @@ public class CspSavedNotificationHandlerTests
 	public void Handle_FrontEndSave_ClearsFrontEndCacheKey()
 	{
 		var notification = new CspSavedNotification(new CspDefinition { IsBackOffice = false });
-		_serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(ServerRole.Single);
 
 		_handler.Handle(notification);
 
@@ -60,26 +55,15 @@ public class CspSavedNotificationHandlerTests
 		_runtimeCache.Verify(c => c.ClearByKey(Constants.BackOfficeCacheKey), Times.Never);
 	}
 
+	// A save can be handled by any server in a load balanced setup, so the invalidation is broadcast
+	// unconditionally - it is no longer gated on this server being the scheduling publisher.
 	[Test]
-	public void Handle_WhenSchedulingPublisher_TriggersDistributedCacheRefresh()
+	public void Handle_TriggersDistributedCacheRefresh()
 	{
 		var notification = new CspSavedNotification(new CspDefinition { IsBackOffice = true });
-		_serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(ServerRole.SchedulingPublisher);
 
 		_handler.Handle(notification);
 
 		Assert.That(_serverMessenger.PayloadRefreshCount, Is.EqualTo(1));
 	}
-
-	[Test]
-	public void Handle_WhenNotSchedulingPublisher_DoesNotTriggerDistributedCacheRefresh()
-	{
-		var notification = new CspSavedNotification(new CspDefinition { IsBackOffice = true });
-		_serverRoleAccessor.Setup(x => x.CurrentServerRole).Returns(ServerRole.Subscriber);
-
-		_handler.Handle(notification);
-
-		Assert.That(_serverMessenger.PayloadRefreshCount, Is.Zero);
-	}
-
 }

--- a/src/Umbraco.Community.CSPManager.Tests/Services/CspServiceTests.cs
+++ b/src/Umbraco.Community.CSPManager.Tests/Services/CspServiceTests.cs
@@ -228,15 +228,10 @@ public class CspServiceTests : UmbracoIntegrationTest
 		var definition2 = await service.GetCachedCspDefinitionAsync(isBackOfficeRequest: true, CancellationToken.None);
 
 		Assert.That(definition1, Is.Not.Null);
-		// A database load builds a new instance, so the same instance twice means the second call
-		// was served from the cache rather than re-queried.
+		// Same instance implies the second call was served from cache, not re-queried.
 		Assert.That(definition2, Is.SameAs(definition1));
 	}
 
-	// The entry has to be in the cache before the database load is awaited. If it were added
-	// afterwards, an invalidation raised while the load was in flight would be silently undone by the
-	// late insert - and because these entries never expire, the stale policy would be served until
-	// the site recycled.
 	[Test]
 	public async Task GetCachedCspDefinitionAsync_CachesTheLoadBeforeAwaitingIt()
 	{
@@ -269,8 +264,8 @@ public class CspServiceTests : UmbracoIntegrationTest
 			"a load that started before the invalidation must not repopulate the cache");
 	}
 
-	// The integration host registers AppCaches.NoCache, so the service and the saved-notification
-	// handler are wired up here against a shared real cache to exercise the invalidation end to end.
+	// Wires the service and saved-notification handler up against a shared real cache to
+	// exercise the invalidation end to end.
 	[Test]
 	public async Task SaveCspDefinitionAsync_InvalidatesTheCachedDefinition()
 	{

--- a/src/Umbraco.Community.CSPManager.Tests/Services/CspServiceTests.cs
+++ b/src/Umbraco.Community.CSPManager.Tests/Services/CspServiceTests.cs
@@ -10,6 +10,7 @@ using Umbraco.Cms.Tests.Common.Testing;
 using Umbraco.Cms.Tests.Integration.Testing;
 using Umbraco.Community.CSPManager.Models;
 using Umbraco.Community.CSPManager.Notifications;
+using Umbraco.Community.CSPManager.Notifications.Handlers;
 using Umbraco.Community.CSPManager.Services;
 using Umbraco.Community.CSPManager.Tests.Helpers;
 
@@ -220,43 +221,102 @@ public class CspServiceTests : UmbracoIntegrationTest
 	[Test]
 	public async Task GetCachedCspDefinitionAsync_CachesResult()
 	{
-		// Create a spy cache that counts factory calls
-		var httpContextAccessor = GetRequiredService<IHttpContextAccessor>();
-		var requestCache = new HttpContextRequestAppCache(httpContextAccessor);
-		var realCache = AppCaches.Create(requestCache).RuntimeCache;
-		var factoryCallCount = 0;
-		var spyCache = Mock.Of<IAppPolicyCache>();
+		var caches = AppCaches.Create(NoAppCache.Instance);
+		var service = new CspService(GetRequiredService<IEventAggregator>(), ScopeProvider, caches, NullLogger<CspService>.Instance);
 
-		Mock.Get(spyCache)
-			.Setup(x => x.Get(It.IsAny<string>()))
-			.Returns((string key) => realCache.Get(key));
+		var definition1 = await service.GetCachedCspDefinitionAsync(isBackOfficeRequest: true, CancellationToken.None);
+		var definition2 = await service.GetCachedCspDefinitionAsync(isBackOfficeRequest: true, CancellationToken.None);
 
-		Mock.Get(spyCache)
-			.Setup(x => x.Insert(It.IsAny<string>(), It.IsAny<Func<object>>(), It.IsAny<TimeSpan?>(), It.IsAny<bool>()))
-			.Callback((string key, Func<object> factory, TimeSpan? _, bool _) =>
-			{
-				// Use real cache but count factory calls
-				realCache.Insert(key, () =>
+		Assert.That(definition1, Is.Not.Null);
+		// A database load builds a new instance, so the same instance twice means the second call
+		// was served from the cache rather than re-queried.
+		Assert.That(definition2, Is.SameAs(definition1));
+	}
+
+	// The entry has to be in the cache before the database load is awaited. If it were added
+	// afterwards, an invalidation raised while the load was in flight would be silently undone by the
+	// late insert - and because these entries never expire, the stale policy would be served until
+	// the site recycled.
+	[Test]
+	public async Task GetCachedCspDefinitionAsync_CachesTheLoadBeforeAwaitingIt()
+	{
+		var caches = AppCaches.Create(NoAppCache.Instance);
+		var service = new CspService(GetRequiredService<IEventAggregator>(), ScopeProvider, caches, NullLogger<CspService>.Instance);
+
+		// Not awaited yet: everything up to the first await has run, including the cache insert.
+		var pending = service.GetCachedCspDefinitionAsync(isBackOfficeRequest: false, CancellationToken.None);
+
+		Assert.That(caches.RuntimeCache.Get(Constants.FrontEndCacheKey), Is.Not.Null,
+			"the in-flight load should already be cached");
+
+		await pending;
+	}
+
+	[Test]
+	public async Task GetCachedCspDefinitionAsync_WhenClearedMidLoad_DoesNotReCacheTheStaleLoad()
+	{
+		var caches = AppCaches.Create(NoAppCache.Instance);
+		var service = new CspService(GetRequiredService<IEventAggregator>(), ScopeProvider, caches, NullLogger<CspService>.Instance);
+
+		var pending = service.GetCachedCspDefinitionAsync(isBackOfficeRequest: false, CancellationToken.None);
+
+		// A save landing while the load is in flight.
+		caches.RuntimeCache.ClearByKey(Constants.FrontEndCacheKey);
+
+		await pending;
+
+		Assert.That(caches.RuntimeCache.Get(Constants.FrontEndCacheKey), Is.Null,
+			"a load that started before the invalidation must not repopulate the cache");
+	}
+
+	// The integration host registers AppCaches.NoCache, so the service and the saved-notification
+	// handler are wired up here against a shared real cache to exercise the invalidation end to end.
+	[Test]
+	public async Task SaveCspDefinitionAsync_InvalidatesTheCachedDefinition()
+	{
+		var caches = AppCaches.Create(NoAppCache.Instance);
+		var distributedCache = new DistributedCache(
+			new SpyServerMessenger(),
+			new CacheRefresherCollection(() => new ICacheRefresher[] { new StubCacheRefresher() }));
+		var handler = new CspSavedNotificationHandler(caches, distributedCache);
+
+		var eventAggregator = Mock.Of<IEventAggregator>();
+		Mock.Get(eventAggregator)
+			.Setup(x => x.PublishAsync(It.IsAny<CspSavedNotification>(), It.IsAny<CancellationToken>()))
+			.Callback<CspSavedNotification, CancellationToken>((notification, _) => handler.Handle(notification))
+			.Returns(Task.CompletedTask);
+
+		var service = new CspService(eventAggregator, ScopeProvider, caches, NullLogger<CspService>.Instance);
+
+		await service.GetCachedCspDefinitionAsync(isBackOfficeRequest: false, CancellationToken.None);
+		Assert.That(caches.RuntimeCache.Get(Constants.FrontEndCacheKey), Is.Not.Null);
+
+		await service.SaveCspDefinitionAsync(new CspDefinition
+		{
+			Id = Constants.DefaultFrontEndId,
+			Enabled = true,
+			IsBackOffice = false,
+			Sources =
+			[
+				new()
 				{
-					factoryCallCount++;
-					return factory();
-				});
-			});
+					DefinitionId = Constants.DefaultFrontEndId,
+					Source = "'self'",
+					Directives = [Constants.Directives.DefaultSource]
+				}
+			]
+		}, CancellationToken.None);
 
+		Assert.That(caches.RuntimeCache.Get(Constants.FrontEndCacheKey), Is.Null,
+			"saving should invalidate the cached definition");
 
-		var spyCaches = new AppCaches(spyCache, requestCache, new IsolatedCaches(_ => spyCache));
-		var spyService = new CspService(GetRequiredService<IEventAggregator>(), ScopeProvider, spyCaches, NullLogger<CspService>.Instance);
+		var reloaded = await service.GetCachedCspDefinitionAsync(isBackOfficeRequest: false, CancellationToken.None);
 
-		// Call GetCachedCspDefinition twice
-		var definition1 = await spyService.GetCachedCspDefinitionAsync(isBackOfficeRequest: true, CancellationToken.None);
-		var definition2 = await spyService.GetCachedCspDefinitionAsync(isBackOfficeRequest: true, CancellationToken.None);
-
-		// Factory should only be called once (first call), second should come from cache
+		Assert.That(reloaded, Is.Not.Null);
 		Assert.Multiple(() =>
 		{
-			Assert.That(definition1, Is.Not.Null);
-			Assert.That(definition2, Is.Not.Null);
-			Assert.That(factoryCallCount, Is.EqualTo(1), "Factory should only be called once - second call should use cache");
+			Assert.That(reloaded.Enabled, Is.True);
+			Assert.That(reloaded.Sources, Has.Count.EqualTo(1));
 		});
 	}
 

--- a/src/Umbraco.Community.CSPManager/CLAUDE.md
+++ b/src/Umbraco.Community.CSPManager/CLAUDE.md
@@ -13,15 +13,11 @@
 
 - Dual context: separate policies for frontend (`fac780be-...`) and backoffice (`9cbfa28c-...`)
 - Cache-first retrieval with distributed cache invalidation on save
-- Cache invalidation ordering matters and is easy to regress:
-  - `GetCachedCspDefinitionAsync` caches the in-flight `Task`, not the awaited result, so the entry
-    exists before the database load runs. Awaiting first and inserting afterwards lets a load that
-    started before a save write its stale result back over the invalidation — and these entries have
-    no expiry, so the old policy is then served until the site recycles.
-  - `SaveCspDefinitionAsync` publishes `CspSavedNotification` only after the scope is disposed, i.e.
-    after the transaction commits, so nothing can reload pre-save rows into the cache.
-  - Invalidation is broadcast for every server role: a save is handled by whichever server the
-    editor is on, not necessarily the scheduling publisher.
+- Cache invalidation ordering is easy to regress: `GetCachedCspDefinitionAsync` caches the
+  in-flight `Task` (not the awaited result) so a concurrent save can't overwrite an invalidation
+  with a stale result; `SaveCspDefinitionAsync` publishes `CspSavedNotification` only after the
+  scope disposes (post-commit); invalidation broadcasts to every server, not just the scheduling
+  publisher, since a save can land on any of them.
 - Nonce-per-request: cryptographically secure, reused within HTTP context
 - Middleware never breaks requests on failure
 - Composer pattern: `CspManagerComposer` auto-registers via `IComposer`

--- a/src/Umbraco.Community.CSPManager/CLAUDE.md
+++ b/src/Umbraco.Community.CSPManager/CLAUDE.md
@@ -13,6 +13,15 @@
 
 - Dual context: separate policies for frontend (`fac780be-...`) and backoffice (`9cbfa28c-...`)
 - Cache-first retrieval with distributed cache invalidation on save
+- Cache invalidation ordering matters and is easy to regress:
+  - `GetCachedCspDefinitionAsync` caches the in-flight `Task`, not the awaited result, so the entry
+    exists before the database load runs. Awaiting first and inserting afterwards lets a load that
+    started before a save write its stale result back over the invalidation — and these entries have
+    no expiry, so the old policy is then served until the site recycles.
+  - `SaveCspDefinitionAsync` publishes `CspSavedNotification` only after the scope is disposed, i.e.
+    after the transaction commits, so nothing can reload pre-save rows into the cache.
+  - Invalidation is broadcast for every server role: a save is handled by whichever server the
+    editor is on, not necessarily the scheduling publisher.
 - Nonce-per-request: cryptographically secure, reused within HTTP context
 - Middleware never breaks requests on failure
 - Composer pattern: `CspManagerComposer` auto-registers via `IComposer`

--- a/src/Umbraco.Community.CSPManager/Notifications/Handlers/CspDistributedCacheRefresher.cs
+++ b/src/Umbraco.Community.CSPManager/Notifications/Handlers/CspDistributedCacheRefresher.cs
@@ -27,10 +27,8 @@ public class CspDistributedCacheRefresher
 	public override Guid RefresherUniqueId => UniqueId;
 	public override string Name => "CspDistCacheRefresher";
 
-	// Deliberately not filtered by server role. Umbraco delivers a refresh instruction to every
-	// server, including the one that raised it, and a save can be raised on any of them - a
-	// subscriber-only guard meant an instruction arriving at a scheduling publisher was ignored and
-	// that server kept serving the old policy. Clearing an already cleared key is a no-op.
+	// Not filtered by server role: a save can be raised on any server, so a subscriber-only guard
+	// left the raising server's own instruction ignored and serving a stale policy.
 	public override void Refresh(CspSavedNotification[] payloads)
 	{
 		foreach (var payload in payloads)

--- a/src/Umbraco.Community.CSPManager/Notifications/Handlers/CspDistributedCacheRefresher.cs
+++ b/src/Umbraco.Community.CSPManager/Notifications/Handlers/CspDistributedCacheRefresher.cs
@@ -2,7 +2,6 @@
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Serialization;
-using Umbraco.Cms.Core.Sync;
 using Umbraco.Community.CSPManager.Logging;
 
 namespace Umbraco.Community.CSPManager.Notifications.Handlers;
@@ -11,12 +10,10 @@ public class CspDistributedCacheRefresher
 	: PayloadCacheRefresherBase<CspDistCacheRefresherNotification, CspSavedNotification>
 {
 	private readonly IAppPolicyCache _runtimeCache;
-	private readonly IServerRoleAccessor _serverRoleAccessor;
 	private readonly ILogger<CspDistributedCacheRefresher> _logger;
 
 	public CspDistributedCacheRefresher(
 			AppCaches appCaches,
-			IServerRoleAccessor serverRoleAccessor,
 			IJsonSerializer serializer,
 			ILogger<CspDistributedCacheRefresher> logger,
 			IEventAggregator eventAggregator,
@@ -24,33 +21,31 @@ public class CspDistributedCacheRefresher
 	) : base(appCaches, serializer, eventAggregator, factory)
 	{
 		_runtimeCache = appCaches.RuntimeCache;
-		_serverRoleAccessor = serverRoleAccessor;
 		_logger = logger;
 	}
 	public static Guid UniqueId => new("8b066ef2-f5ec-4b6f-8121-952c0c7b9d21");
 	public override Guid RefresherUniqueId => UniqueId;
 	public override string Name => "CspDistCacheRefresher";
+
+	// Deliberately not filtered by server role. Umbraco delivers a refresh instruction to every
+	// server, including the one that raised it, and a save can be raised on any of them - a
+	// subscriber-only guard meant an instruction arriving at a scheduling publisher was ignored and
+	// that server kept serving the old policy. Clearing an already cleared key is a no-op.
 	public override void Refresh(CspSavedNotification[] payloads)
 	{
-		if (_serverRoleAccessor.CurrentServerRole == ServerRole.Subscriber)
+		foreach (var payload in payloads)
 		{
-			foreach (var payload in payloads)
-			{
-				var cacheKey = payload.CspDefinition.IsBackOffice
-					? Constants.BackOfficeCacheKey
-					: Constants.FrontEndCacheKey;
-				Log.ClearingCspCache(_logger, cacheKey);
-				_runtimeCache.ClearByKey(cacheKey);
-			}
+			var cacheKey = payload.CspDefinition.IsBackOffice
+				? Constants.BackOfficeCacheKey
+				: Constants.FrontEndCacheKey;
+			Log.ClearingCspCache(_logger, cacheKey);
+			_runtimeCache.ClearByKey(cacheKey);
 		}
 	}
 	public override void RefreshAll()
 	{
-		if (_serverRoleAccessor.CurrentServerRole == ServerRole.Subscriber)
-		{
-			Log.ClearingAllCspCaches(_logger);
-			_runtimeCache.ClearByKey(Constants.BackOfficeCacheKey);
-			_runtimeCache.ClearByKey(Constants.FrontEndCacheKey);
-		}
+		Log.ClearingAllCspCaches(_logger);
+		_runtimeCache.ClearByKey(Constants.BackOfficeCacheKey);
+		_runtimeCache.ClearByKey(Constants.FrontEndCacheKey);
 	}
 }

--- a/src/Umbraco.Community.CSPManager/Notifications/Handlers/CspSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.CSPManager/Notifications/Handlers/CspSavedNotificationHandler.cs
@@ -21,13 +21,8 @@ internal sealed class CspSavedNotificationHandler : INotificationHandler<CspSave
 	{
 		string cacheKey = notification.CspDefinition.IsBackOffice ? Constants.BackOfficeCacheKey : Constants.FrontEndCacheKey;
 
-		// Clear locally first so this server serves the new policy immediately whatever its role,
-		// and regardless of how the messenger is configured.
+		// Clear locally first so this server serves the new policy immediately, then broadcast to the rest.
 		_runtimeCache.ClearByKey(cacheKey);
-
-		// Then tell the other servers. This is not limited to the scheduling publisher: a back
-		// office save is served by whichever server the editor happens to be on, so restricting the
-		// broadcast to publishers left every other server serving the old policy until it recycled.
 		_distributedCache.RefreshByPayload(CspDistributedCacheRefresher.UniqueId, [notification]);
 	}
 }

--- a/src/Umbraco.Community.CSPManager/Notifications/Handlers/CspSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.CSPManager/Notifications/Handlers/CspSavedNotificationHandler.cs
@@ -1,22 +1,18 @@
 ﻿using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Events;
-using Umbraco.Cms.Core.Sync;
 
 namespace Umbraco.Community.CSPManager.Notifications.Handlers;
 
 internal sealed class CspSavedNotificationHandler : INotificationHandler<CspSavedNotification>
 {
 	private readonly IAppPolicyCache _runtimeCache;
-	private readonly IServerRoleAccessor _serverRoleAccessor;
 	private readonly DistributedCache _distributedCache;
 
 	public CspSavedNotificationHandler(
-		IServerRoleAccessor serverRoleAccessor,
 		AppCaches appCaches,
 		DistributedCache distributedCache
 	)
 	{
-		_serverRoleAccessor = serverRoleAccessor;
 		_runtimeCache = appCaches.RuntimeCache;
 		_distributedCache = distributedCache;
 	}
@@ -24,11 +20,14 @@ internal sealed class CspSavedNotificationHandler : INotificationHandler<CspSave
 	public void Handle(CspSavedNotification notification)
 	{
 		string cacheKey = notification.CspDefinition.IsBackOffice ? Constants.BackOfficeCacheKey : Constants.FrontEndCacheKey;
+
+		// Clear locally first so this server serves the new policy immediately whatever its role,
+		// and regardless of how the messenger is configured.
 		_runtimeCache.ClearByKey(cacheKey);
 
-		if (_serverRoleAccessor.CurrentServerRole == ServerRole.SchedulingPublisher)
-		{
-			_distributedCache.RefreshByPayload(CspDistributedCacheRefresher.UniqueId, [notification]);
-		}
+		// Then tell the other servers. This is not limited to the scheduling publisher: a back
+		// office save is served by whichever server the editor happens to be on, so restricting the
+		// broadcast to publishers left every other server serving the old policy until it recycled.
+		_distributedCache.RefreshByPayload(CspDistributedCacheRefresher.UniqueId, [notification]);
 	}
 }

--- a/src/Umbraco.Community.CSPManager/Services/CspService.cs
+++ b/src/Umbraco.Community.CSPManager/Services/CspService.cs
@@ -47,30 +47,29 @@ internal sealed class CspService : ICspService
 		var context = isBackOfficeRequest ? "BackOffice" : "Frontend";
 		var factoryCalled = false;
 
-		// What goes in the cache is the load itself, not its result, and IAppPolicyCache.Get adds it
-		// under a lock before the database round-trip is awaited. That ordering is what makes
-		// invalidation reliable: if a save clears this key while a load is still in flight, the entry
-		// has already been added and removed, so the load cannot write its now-stale result back over
-		// the clear. Awaiting first and inserting afterwards loses that race, and because these
-		// entries never expire the stale policy would then be served until the site recycled.
-		// It also means concurrent requests await one shared load instead of each hitting the database.
+		// IAppPolicyCache.Get holds a lock while it claims the cache slot, so the Task we return
+		// here is inserted synchronously - before the DB call it wraps has even started - rather
+		// than after it completes like GetCacheItemAsync would. That closes a race where a save's
+		// ClearByKey fires while a load is in flight: the entry it clears actually exists, so the
+		// load can't resurrect stale data by inserting its result afterwards. It also means
+		// concurrent callers for the same key share this one Task instead of each hitting the DB.
 		var load = (Task<CspDefinition>)_runtimeCache.Get(cacheKey, () =>
 		{
 			factoryCalled = true;
 
-			// Deliberately not the caller's token: this load is shared by every request waiting on
-			// the same key, so one client disconnecting must not fault it for all the others.
+			// Not the caller's token: this load is shared by every request waiting on the same key.
 			return GetCspDefinitionAsync(isBackOfficeRequest, CancellationToken.None);
 		}, timeout: null)!;
 
 		CspDefinition definition;
+
 		try
 		{
 			definition = await load.WaitAsync(cancellationToken);
 		}
 		catch (Exception) when (load.IsFaulted)
 		{
-			// A failed load must not stay cached, or every later request replays the same failure.
+			// Don't leave a failed load cached, or every later request replays the same failure.
 			_runtimeCache.Clear(cacheKey);
 			throw;
 		}
@@ -159,9 +158,8 @@ internal sealed class CspService : ICspService
 				scope.Complete();
 			}
 
-			// Published after the scope is disposed, because that is when the transaction actually
-			// commits. Invalidating the cache while the write is still uncommitted lets a request
-			// arriving in that window reload the pre-save rows and cache them again.
+			// Publish after the scope disposes, i.e. after commit - otherwise a request in that
+			// window could reload the pre-save rows and cache them.
 			await _eventAggregator.PublishAsync(new CspSavedNotification(definition), cancellationToken);
 
 			Log.CspDefinitionSaved(_logger, definition.Id, definition.Sources.Count);

--- a/src/Umbraco.Community.CSPManager/Services/CspService.cs
+++ b/src/Umbraco.Community.CSPManager/Services/CspService.cs
@@ -47,18 +47,40 @@ internal sealed class CspService : ICspService
 		var context = isBackOfficeRequest ? "BackOffice" : "Frontend";
 		var factoryCalled = false;
 
-		var result = await _runtimeCache.GetCacheItemAsync(cacheKey, async () =>
+		// What goes in the cache is the load itself, not its result, and IAppPolicyCache.Get adds it
+		// under a lock before the database round-trip is awaited. That ordering is what makes
+		// invalidation reliable: if a save clears this key while a load is still in flight, the entry
+		// has already been added and removed, so the load cannot write its now-stale result back over
+		// the clear. Awaiting first and inserting afterwards loses that race, and because these
+		// entries never expire the stale policy would then be served until the site recycled.
+		// It also means concurrent requests await one shared load instead of each hitting the database.
+		var load = (Task<CspDefinition>)_runtimeCache.Get(cacheKey, () =>
 		{
 			factoryCalled = true;
-			return await GetCspDefinitionAsync(isBackOfficeRequest, cancellationToken);
-		}, timeout: null);
 
-		if (!factoryCalled && result is not null)
+			// Deliberately not the caller's token: this load is shared by every request waiting on
+			// the same key, so one client disconnecting must not fault it for all the others.
+			return GetCspDefinitionAsync(isBackOfficeRequest, CancellationToken.None);
+		}, timeout: null)!;
+
+		CspDefinition definition;
+		try
 		{
-			Log.CspDefinitionRetrievedFromCache(_logger, result.Id, context);
+			definition = await load.WaitAsync(cancellationToken);
+		}
+		catch (Exception) when (load.IsFaulted)
+		{
+			// A failed load must not stay cached, or every later request replays the same failure.
+			_runtimeCache.Clear(cacheKey);
+			throw;
 		}
 
-		return result;
+		if (!factoryCalled)
+		{
+			Log.CspDefinitionRetrievedFromCache(_logger, definition.Id, context);
+		}
+
+		return definition;
 	}
 
 	public async Task<CspDefinition?> GetCspDefinitionAsync(Guid key, CancellationToken cancellationToken)
@@ -130,12 +152,16 @@ internal sealed class CspService : ICspService
 
 		try
 		{
-			using var scope = _scopeProvider.CreateScope();
+			using (var scope = _scopeProvider.CreateScope())
+			{
+				definition = await SaveDefinitionAsync(scope, definition, cancellationToken);
 
-			definition = await SaveDefinitionAsync(scope, definition, cancellationToken);
+				scope.Complete();
+			}
 
-			scope.Complete();
-
+			// Published after the scope is disposed, because that is when the transaction actually
+			// commits. Invalidating the cache while the write is still uncommitted lets a request
+			// arriving in that window reload the pre-save rows and cache them again.
 			await _eventAggregator.PublishAsync(new CspSavedNotification(definition), cancellationToken);
 
 			Log.CspDefinitionSaved(_logger, definition.Id, definition.Sources.Count);


### PR DESCRIPTION
Saving a policy cleared the runtime cache, but three separate ordering
problems could leave the old policy being served afterwards. The entries
have no expiry, so once any of them hit, the stale header persisted until
the site recycled.

- GetCachedCspDefinitionAsync now caches the in-flight load rather than
  the awaited result. AppCacheExtensions.GetCacheItemAsync does
  Get -> await -> Insert, so a load that started before a save inserted
  its stale result back over the ClearByKey that happened during the
  await. Caching the Task via IAppPolicyCache.Get puts the entry in place
  before the database round-trip, so a clear during the load sticks. It
  also restores the single-flight behaviour the middleware comment
  already assumed, and evicts the key if the load faults so a failure is
  not cached forever.

- SaveCspDefinitionAsync publishes CspSavedNotification after the scope
  is disposed instead of inside it. Previously the cache was invalidated
  while the write was still uncommitted, so a request arriving in that
  window reloaded and cached the pre-save rows.

- Invalidation is now broadcast for every server role. The handler only
  called DistributedCache.RefreshByPayload when the server was the
  scheduling publisher, and the refresher only cleared when it was a
  subscriber, so in a load balanced setup a save served by a subscriber
  never reached the other servers and an instruction arriving at a
  publisher was ignored. Umbraco delivers refresh instructions locally as
  well as remotely, and clearing an already cleared key is a no-op.

IServerRoleAccessor is no longer needed by either type and has been
removed from their constructors.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rn8rvNgVF8HRuxoA3q7xRk