### PR TITLE
fix(ci): stop central transitive pinning forcing a stable CSP Manager…

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,8 +14,12 @@
     <PackageVersion Include="uSync.BackOffice" Version="18.0.2" />
     <PackageVersion Include="uSync.Complete" Version="18.0.2" />
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" />
-    <PackageVersion Include="Umbraco.Community.CSPManager" Version="18.0.0" />
-    <PackageVersion Include="Umbraco.Community.CSPManager.uSync" Version="18.0.0" />
+    <!-- Range (not a pin) so central transitive pinning doesn't force a stable version
+         onto the transitive CSP Manager dependency when packing uSync.Complete against
+         a prerelease. Mirrors the dependency range the packages declare; the release
+         workflow overrides the floor for prerelease builds. See Directory.Build.props. -->
+    <PackageVersion Include="Umbraco.Community.CSPManager" Version="$(CspManagerDependencyRange)" />
+    <PackageVersion Include="Umbraco.Community.CSPManager.uSync" Version="$(CspManagerDependencyRange)" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="SystemTextJson.JsonDiffPatch.NUnit" Version="2.0.0" />


### PR DESCRIPTION
Directory.Packages.props pinned Umbraco.Community.CSPManager(.uSync) to a stable 18.0.0 with CentralPackageTransitivePinningEnabled=true. When packing uSync.Complete against a prerelease, transitive pinning overrode the [18.0.0-beta-1, 19.0.0) range in uSync's nuspec and forced the transitive main dependency to >= 18.0.0 stable, which excludes the only published 18.x (18.0.0-beta-1) -> NU1102. Packing uSync itself was fine because there main is a direct reference with VersionOverride, which beats central pinning.

Point both central versions at $(CspManagerDependencyRange) so the pin is a range that mirrors the declared dependency and honours the release workflow's prerelease floor override. Verified locally: Complete restores against 18.0.0-beta-1, and dev-mode (ProjectReference) restore is unchanged.