### PR TITLE
fix(ci): publish from release.yml to match NuGet trusted-publishing policy

### DIFF
--- a/.github/workflows/csp-manager.yml
+++ b/.github/workflows/csp-manager.yml
@@ -1,8 +1,9 @@
 name: CSP Manager Build
 
+# Build + test validation only. Releases publish from release.yml — NuGet's
+# trusted-publishing policy requires that exact workflow filename.
+
 on:
-  release:
-    types: [published]
   push:
     branches:
       - main
@@ -26,7 +27,6 @@ on:
 
 jobs:
   build:
-    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'usync-')
     permissions:
       contents: read
       pull-requests: write
@@ -36,7 +36,7 @@ jobs:
       PROJECT: "./src/Umbraco.Community.CSPManager/Umbraco.Community.CSPManager.csproj"
       TESTPROJECT: "./src/Umbraco.Community.CSPManager.Tests/Umbraco.Community.CSPManager.Tests.csproj"
       TESTLOGPATH: "./src/Umbraco.Community.CSPManager.Tests/TestResults/"
-      BUILD_VERSION: ${{ github.event.release.tag_name || '0.0.0' }}
+      BUILD_VERSION: "0.0.0"
       OUT_FOLDER: ./build-out/
 
     runs-on: ubuntu-latest
@@ -88,39 +88,3 @@ jobs:
         with:
           name: nuget-packages
           path: ${{env.OUT_FOLDER}}
-
-  release:
-    needs: build
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    environment: nuget-csp
-    permissions:
-      id-token: write
-      attestations: write
-      contents: read
-
-    steps:
-      - name: Download nuget packages
-        uses: actions/download-artifact@v4
-        with:
-          name: nuget-packages
-          path: ./build-out/
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: './build-out/*.nupkg'
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 10.0.x
-
-      - name: NuGet login
-        uses: NuGet/login@v1
-        id: nuget-login
-        with:
-          user: MattWise
-
-      - name: Publish to NuGet
-        run: dotnet nuget push ./build-out/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,187 @@
+name: Release
+
+# NuGet's trusted-publishing policies for this repo require the OIDC token
+# exchange to come from a workflow file named exactly "release.yml" (they
+# were repointed here when main moved to a unified pipeline). Publishing
+# from any other filename fails token exchange with a 401 workflow mismatch,
+# so the actual `dotnet nuget push` steps for all three packages live here,
+# even though this branch still triggers/builds each package independently.
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - 'usync-*'
+      - 'usync-complete-*'
+
+env:
+  PROJECT: "./src/Umbraco.Community.CSPManager/Umbraco.Community.CSPManager.csproj"
+  TESTPROJECT: "./src/Umbraco.Community.CSPManager.Tests/Umbraco.Community.CSPManager.Tests.csproj"
+  USYNC_PROJECT: "./src/uSync/Umbraco.Community.CSPManager.uSync/Umbraco.Community.CSPManager.uSync.csproj"
+  COMPLETE_PROJECT: "./src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Umbraco.Community.CSPManager.uSync.Complete.csproj"
+  OUT_FOLDER: ./build-out/
+
+jobs:
+  release-csp-manager:
+    if: github.event_name == 'release' && !startsWith(github.event.release.tag_name, 'usync-')
+    runs-on: ubuntu-latest
+    environment: nuget-csp
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
+    env:
+      BUILD_VERSION: ${{ github.event.release.tag_name }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: './src/Umbraco.Community.CSPManager/Client/package.json'
+          cache: 'npm'
+          cache-dependency-path: './src/Umbraco.Community.CSPManager/Client/package-lock.json'
+
+      - name: Install client dependencies
+        run: npm ci
+        working-directory: ./src/Umbraco.Community.CSPManager/Client
+
+      - name: Build client
+        run: npm run build
+        working-directory: ./src/Umbraco.Community.CSPManager/Client
+
+      - name: Run tests
+        run: dotnet test $TESTPROJECT -c Release --verbosity normal --filter "Category!=LongRunning"
+
+      - name: Build & Pack
+        run: dotnet pack $PROJECT -c Release -p:Version=$BUILD_VERSION --output ${{env.OUT_FOLDER}}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: '${{ env.OUT_FOLDER }}*.nupkg'
+
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: MattWise
+
+      - name: Publish to NuGet
+        run: dotnet nuget push ${{ env.OUT_FOLDER }}*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+  release-usync:
+    if: startsWith(github.ref, 'refs/tags/usync-') && !startsWith(github.ref, 'refs/tags/usync-complete-')
+    runs-on: ubuntu-latest
+    environment: nuget-usync
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/usync-}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build & Pack
+        run: dotnet pack ${{ env.USYNC_PROJECT }} -c Release -p:Version=${{ steps.version.outputs.version }} -p:UseProjectReferences=false --output ${{ env.OUT_FOLDER }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: '${{ env.OUT_FOLDER }}*.nupkg'
+
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: MattWise
+
+      - name: Publish to NuGet
+        run: |
+          for package in ${{ env.OUT_FOLDER }}*.nupkg; do
+            echo "Publishing $package"
+            dotnet nuget push "$package" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          done
+
+  release-usync-complete:
+    if: startsWith(github.ref, 'refs/tags/usync-complete-')
+    runs-on: ubuntu-latest
+    environment: nuget-usync-complete
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/usync-complete-}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: './src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client/package.json'
+          cache: 'npm'
+          cache-dependency-path: './src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client/package-lock.json'
+
+      - name: Install client dependencies
+        run: npm ci
+        working-directory: ./src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client
+
+      - name: Build client
+        run: npm run build
+        working-directory: ./src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client
+
+      - name: Build & Pack
+        run: dotnet pack ${{ env.COMPLETE_PROJECT }} -c Release -p:Version=${{ steps.version.outputs.version }} -p:UseProjectReferences=false --output ${{ env.OUT_FOLDER }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: '${{ env.OUT_FOLDER }}*.nupkg'
+
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: MattWise
+
+      - name: Publish to NuGet
+        run: |
+          for package in ${{ env.OUT_FOLDER }}*.nupkg; do
+            echo "Publishing $package"
+            dotnet nuget push "$package" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          done

--- a/.github/workflows/usync.yml
+++ b/.github/workflows/usync.yml
@@ -1,5 +1,8 @@
 name: uSync Build
 
+# Build + pack validation only. Releases publish from release.yml — NuGet's
+# trusted-publishing policy requires that exact workflow filename.
+
 on:
   push:
     branches:
@@ -9,9 +12,6 @@ on:
       - 'src/Directory.Build.props'
       - 'src/Directory.Packages.props'
       - '.github/workflows/usync.yml'
-    tags:
-      - 'usync-*'
-      - 'usync-complete-*'
   pull_request:
     branches:
       - main
@@ -68,112 +68,3 @@ jobs:
         with:
           name: uSync Build Output
           path: ${{ env.OUT_FOLDER }}
-
-  release-usync:
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/usync-') && !startsWith(github.ref, 'refs/tags/usync-complete-')
-    runs-on: ubuntu-latest
-    environment: nuget-usync
-    permissions:
-      id-token: write
-      attestations: write
-      contents: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/usync-}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION"
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 10.0.x
-
-      - name: Build & Pack
-        run: dotnet pack ${{ env.USYNC_PROJECT }} -c Release -p:Version=${{ steps.version.outputs.version }} -p:UseProjectReferences=false --output ${{ env.OUT_FOLDER }}
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: '${{ env.OUT_FOLDER }}*.nupkg'
-
-      - name: NuGet login
-        uses: NuGet/login@v1
-        id: nuget-login
-        with:
-          user: MattWise
-
-      - name: Publish to NuGet
-        run: |
-          for package in ${{ env.OUT_FOLDER }}*.nupkg; do
-            echo "Publishing $package"
-            dotnet nuget push "$package" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-          done
-
-  release-usync-complete:
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/usync-complete-')
-    runs-on: ubuntu-latest
-    environment: nuget-usync-complete
-    permissions:
-      id-token: write
-      attestations: write
-      contents: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/usync-complete-}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION"
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 10.0.x
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: './src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client/package.json'
-          cache: 'npm'
-          cache-dependency-path: './src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client/package-lock.json'
-
-      - name: Install client dependencies
-        run: npm ci
-        working-directory: ./src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client
-
-      - name: Build client
-        run: npm run build
-        working-directory: ./src/uSync/Umbraco.Community.CSPManager.uSync.Complete/Client
-
-      - name: Build & Pack
-        run: dotnet pack ${{ env.COMPLETE_PROJECT }} -c Release -p:Version=${{ steps.version.outputs.version }} -p:UseProjectReferences=false --output ${{ env.OUT_FOLDER }}
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: '${{ env.OUT_FOLDER }}*.nupkg'
-
-      - name: NuGet login
-        uses: NuGet/login@v1
-        id: nuget-login
-        with:
-          user: MattWise
-
-      - name: Publish to NuGet
-        run: |
-          for package in ${{ env.OUT_FOLDER }}*.nupkg; do
-            echo "Publishing $package"
-            dotnet nuget push "$package" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,11 @@ src/
 
 All packages use major version aligned to Umbraco (e.g. Umbraco 17 → `17.x.x`).
 
-- CSP Manager: GitHub Release tag `17.0.0` (triggers `csp-manager.yml`)
-- uSync: git tag `usync-17.0.0` (triggers `usync.yml` `release-usync` job)
-- uSync Complete: git tag `usync-complete-17.0.0` (triggers `usync.yml` `release-usync-complete` job)
+- CSP Manager: GitHub Release tag `17.0.0` (triggers `release.yml` `release-csp-manager` job)
+- uSync: git tag `usync-17.0.0` (triggers `release.yml` `release-usync` job)
+- uSync Complete: git tag `usync-complete-17.0.0` (triggers `release.yml` `release-usync-complete` job)
+
+All publishing lives in `release.yml` — NuGet's trusted-publishing policies for this repo require the OIDC token-exchange workflow to be named exactly `release.yml`, regardless of branch. `csp-manager.yml`/`usync.yml` are build-only; never add a `dotnet nuget push` step to them.
 
 Each package releases independently. Dependencies use a version range `[17.0.0-0, 18.0.0)` — accepts any 17.x including pre-releases. Only update the lower bound in the `.csproj` when a dependency has a breaking change that requires a newer minimum.
 


### PR DESCRIPTION
## Summary
- The `17.0.3` release run failed NuGet trusted-publishing token exchange (HTTP 401) with `Workflow mismatch for policy 'CSP Manager'/'CSP uSync'/'CSP uSync Complete': expected 'release.yml', actual 'csp-manager.yml'`
- When `main` moved to its unified `release.yml` pipeline, the NuGet trusted-publishing policies for all three packages were repointed to require the OIDC token exchange to come from a workflow file literally named `release.yml`
- This branch still ran the publish steps from `csp-manager.yml`/`usync.yml`, so publishing was broken regardless of code correctness
- Moves the publish jobs into a new `release.yml`, using the same triggers this branch already relies on (GitHub Release for CSP Manager, `usync-*`/`usync-complete-*` tags for uSync/uSync Complete) — does **not** adopt main's `workflow_dispatch`/multi-package rewrite, since this is a maintenance branch
- `csp-manager.yml` and `usync.yml` are now build/test validation only
- Updated `CLAUDE.md`'s CI Release Tags section to match

## Test plan
- [ ] Merge this PR
- [ ] Re-publish the `17.0.3` GitHub Release (or create a new patch release) and confirm `release.yml` runs and publishes successfully to NuGet