### PR TITLE
fix(cache): return a defensive copy from GetCachedCspDefinitionAsync

### DIFF
--- a/src/Umbraco.Community.CSPManager.Tests/Middleware/CspMiddlewareTests.cs
+++ b/src/Umbraco.Community.CSPManager.Tests/Middleware/CspMiddlewareTests.cs
@@ -12,6 +12,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Configuration;
 using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Tests.Integration.Implementations;
@@ -108,6 +109,53 @@ public class CspMiddlewareTests
 		Mock.Get(_cspService).Verify(x => x.GetCachedCspDefinitionAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()), verifyCalls);
 		Mock.Get(_eventAggregator).Verify(x => x.PublishAsync(It.IsAny<CspWritingNotification>(),
 			It.IsAny<CancellationToken>()), verifyCalls);
+	}
+
+	// ICspService.GetCachedCspDefinitionAsync returns a defensive copy on every call
+	// (CspService.CloneDefinition) precisely so that CspWritingNotification handlers can freely
+	// mutate notification.CspDefinition - as the documented pattern in
+	// docs/advanced/notification-events.md does - without corrupting what other requests get
+	// served from the shared cache. This test mocks GetCachedCspDefinitionAsync to hand out a
+	// fresh clone per call, matching that contract, and asserts the middleware/notification
+	// pipeline keeps a handler's mutation scoped to its own request.
+	[Test]
+	public async Task CspMiddleware_WritingNotificationHandlerMutatesDefinition_DoesNotLeakIntoUnrelatedRequests()
+	{
+		Mock.Get(_cspService)
+			.Setup(x => x.GetCachedCspDefinitionAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+			.ReturnsAsync(() => new CspDefinition
+			{
+				Id = Constants.DefaultFrontEndId,
+				Enabled = true,
+				IsBackOffice = false,
+				Sources = [new CspDefinitionSource { Source = "'self'", Directives = [Constants.Directives.DefaultSource] }]
+			});
+
+		Mock.Get(_eventAggregator)
+			.Setup(x => x.PublishAsync(It.IsAny<CspWritingNotification>(), It.IsAny<CancellationToken>()))
+			.Callback<INotification, CancellationToken>((n, _) =>
+			{
+				var notification = (CspWritingNotification)n;
+				if (notification.HttpContext.Request.Path.StartsWithSegments("/api"))
+				{
+					notification.CspDefinition!.Sources.Add(new CspDefinitionSource
+					{
+						Source = "api.example.com",
+						Directives = [Constants.Directives.ConnectSource]
+					});
+				}
+			})
+			.Returns(Task.CompletedTask);
+
+		var apiResponse = await _host.GetTestClient().GetAsync("/api/orders");
+		var apiHeader = apiResponse.Headers.GetValues(Constants.HeaderName).First();
+		Assert.That(apiHeader, Does.Contain("api.example.com"));
+
+		var unrelatedResponse = await _host.GetTestClient().GetAsync("/content/page");
+		var unrelatedHeader = unrelatedResponse.Headers.GetValues(Constants.HeaderName).First();
+
+		Assert.That(unrelatedHeader, Does.Not.Contain("api.example.com"),
+			"a handler scoped to /api requests must not leak its source into unrelated requests");
 	}
 
 	[Test]

--- a/src/Umbraco.Community.CSPManager.Tests/Services/CspServiceTests.cs
+++ b/src/Umbraco.Community.CSPManager.Tests/Services/CspServiceTests.cs
@@ -224,12 +224,60 @@ public class CspServiceTests : UmbracoIntegrationTest
 		var caches = AppCaches.Create(NoAppCache.Instance);
 		var service = new CspService(GetRequiredService<IEventAggregator>(), ScopeProvider, caches, NullLogger<CspService>.Instance);
 
+		await _cspService.SaveCspDefinitionAsync(new CspDefinition
+		{
+			Id = Constants.DefaultBackofficeId,
+			Enabled = true,
+			IsBackOffice = true,
+			Sources = []
+		}, CancellationToken.None);
+
 		var definition1 = await service.GetCachedCspDefinitionAsync(isBackOfficeRequest: true, CancellationToken.None);
+		Assert.That(definition1.Enabled, Is.True);
+
+		// Saved through a different CspService/cache instance (_cspService uses the DI-registered
+		// AppCaches), so `service`'s own cache is never invalidated by this - the row it points at
+		// changes underneath it.
+		await _cspService.SaveCspDefinitionAsync(new CspDefinition
+		{
+			Id = Constants.DefaultBackofficeId,
+			Enabled = false,
+			IsBackOffice = true,
+			Sources = []
+		}, CancellationToken.None);
+
 		var definition2 = await service.GetCachedCspDefinitionAsync(isBackOfficeRequest: true, CancellationToken.None);
 
-		Assert.That(definition1, Is.Not.Null);
-		// Same instance implies the second call was served from cache, not re-queried.
-		Assert.That(definition2, Is.SameAs(definition1));
+		Assert.That(definition2.Enabled, Is.True,
+			"the second call should be served from cache, not reloaded from the database");
+	}
+
+	[Test]
+	public async Task GetCachedCspDefinitionAsync_ReturnsIndependentCopyPerCall()
+	{
+		var caches = AppCaches.Create(NoAppCache.Instance);
+		var service = new CspService(GetRequiredService<IEventAggregator>(), ScopeProvider, caches, NullLogger<CspService>.Instance);
+
+		var definition1 = await service.GetCachedCspDefinitionAsync(isBackOfficeRequest: false, CancellationToken.None);
+		definition1.Enabled = true;
+		definition1.Sources.Add(new CspDefinitionSource
+		{
+			DefinitionId = definition1.Id,
+			Source = "mutated-by-caller",
+			Directives = [Constants.Directives.ConnectSource]
+		});
+
+		var definition2 = await service.GetCachedCspDefinitionAsync(isBackOfficeRequest: false, CancellationToken.None);
+
+		// A caller (e.g. a CspWritingNotification handler following the documented pattern of
+		// mutating notification.CspDefinition) must not be able to corrupt what every other
+		// request sharing the cache sees.
+		Assert.Multiple(() =>
+		{
+			Assert.That(definition2, Is.Not.SameAs(definition1));
+			Assert.That(definition2.Enabled, Is.False);
+			Assert.That(definition2.Sources.Select(s => s.Source), Does.Not.Contain("mutated-by-caller"));
+		});
 	}
 
 	[Test]

--- a/src/Umbraco.Community.CSPManager/CLAUDE.md
+++ b/src/Umbraco.Community.CSPManager/CLAUDE.md
@@ -18,6 +18,11 @@
   with a stale result; `SaveCspDefinitionAsync` publishes `CspSavedNotification` only after the
   scope disposes (post-commit); invalidation broadcasts to every server, not just the scheduling
   publisher, since a save can land on any of them.
+- `GetCachedCspDefinitionAsync` returns a defensive copy (`CloneDefinition`) of the cached
+  instance, never the cached reference itself - `CspWritingNotification` hands the result to
+  consumer code, and the documented handler pattern mutates `CspDefinition.Sources` directly, so
+  returning the shared reference would let one handler's mutation corrupt what every other
+  request sharing the cache sees.
 - Nonce-per-request: cryptographically secure, reused within HTTP context
 - Middleware never breaks requests on failure
 - Composer pattern: `CspManagerComposer` auto-registers via `IComposer`

--- a/src/Umbraco.Community.CSPManager/Services/CspService.cs
+++ b/src/Umbraco.Community.CSPManager/Services/CspService.cs
@@ -79,8 +79,33 @@ internal sealed class CspService : ICspService
 			Log.CspDefinitionRetrievedFromCache(_logger, definition.Id, context);
 		}
 
-		return definition;
+		// The cached instance is shared by every caller until the next save invalidates it -
+		// CspWritingNotification hands it to consumer code, and the documented pattern for that
+		// notification mutates CspDefinition.Sources directly. Handing out the cached reference
+		// itself would let one handler's mutation leak into every other request sharing the
+		// cache. Returning a defensive copy keeps that mutation scoped to its own request.
+		return CloneDefinition(definition);
 	}
+
+	private static CspDefinition CloneDefinition(CspDefinition definition) => new()
+	{
+		Id = definition.Id,
+		Enabled = definition.Enabled,
+		ReportOnly = definition.ReportOnly,
+		IsBackOffice = definition.IsBackOffice,
+		ReportingDirective = definition.ReportingDirective,
+		ReportUri = definition.ReportUri,
+		UpgradeInsecureRequests = definition.UpgradeInsecureRequests,
+		Sources =
+		[
+			.. definition.Sources.Select(s => new CspDefinitionSource
+			{
+				DefinitionId = s.DefinitionId,
+				Source = s.Source,
+				Directives = [.. s.Directives]
+			})
+		]
+	};
 
 	public async Task<CspDefinition?> GetCspDefinitionAsync(Guid key, CancellationToken cancellationToken)
 	{


### PR DESCRIPTION
## Summary
Backport of #136 to the v17 maintenance branch.

- `GetCachedCspDefinitionAsync` previously returned the cached `CspDefinition` instance itself, shared by every request until the next save invalidates the cache.
- `CspWritingNotification` hands that instance straight to handlers, and the documented extensibility pattern (`docs/advanced/notification-events.md`) mutates `CspDefinition.Sources` directly based on the request - so a handler following the docs would corrupt the shared cache entry and leak its mutation into unrelated requests.
- `GetCachedCspDefinitionAsync` now returns a defensive copy (`CloneDefinition`) instead, so callers can mutate freely without affecting what other requests are served. The single-flight `Task` caching (no extra DB round-trips) is unchanged.

## Test plan
- [x] `CspServiceTests.GetCachedCspDefinitionAsync_CachesResult` - rewritten to prove caching via a DB-side-effect check instead of reference identity
- [x] `CspServiceTests.GetCachedCspDefinitionAsync_ReturnsIndependentCopyPerCall` (new)
- [x] `CspMiddlewareTests.CspMiddleware_WritingNotificationHandlerMutatesDefinition_DoesNotLeakIntoUnrelatedRequests` (new)
- [x] `dotnet test` - all 35 tests pass on v17-maintenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)